### PR TITLE
Use MidnightBSD portsnap origin

### DIFF
--- a/ps-cron.sh
+++ b/ps-cron.sh
@@ -3,7 +3,7 @@
 cd /local0/ps-mirror/wrkdir
 
 STIME=`date "+%s"`
-sh -e /root/efs-fup/ps-mirror.sh portsnap-master.freebsd.org /local0/ps-mirror/www
+sh -e /root/efs-fup/ps-mirror.sh portsnap1.midnightbsd.org /local0/ps-mirror/www
 ETIME=`date "+%s"`
 TTIME=`expr $ETIME - $STIME || true`
 if [ $TTIME -lt 60 ]; then


### PR DESCRIPTION
## Summary
- replace the obsolete FreeBSD portsnap master hostname in the cron wrapper
- use portsnap1.midnightbsd.org as the mirror origin

## Verification
- sh -n ps-cron.sh
- git diff --check

## Summary by Sourcery

Bug Fixes:
- Update the portsnap cron wrapper to use the MidnightBSD mirror instead of the obsolete FreeBSD master hostname.