### PR TITLE
Scrub retained portsnap mirror objects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,9 @@ suite.
 ## Running and validating
 
 The scripts target MidnightBSD/FreeBSD: they use `/usr/libexec/phttpget`, `fetch`,
-`lam`, `sha256`, and (in the documented invocation) `lockf`, so a real run needs that
-platform. The test suite, however, stubs the network tools and runs anywhere:
+`lam`, `sha256`, `bspatch`, `tar`, and (in the documented invocation) `lockf`, so a real
+run needs that platform. The test suite, however, stubs the network tools and runs
+anywhere:
 
 ```sh
 sh tests/f2-regression.sh   # full suite; no network, no portsnap server needed
@@ -23,11 +24,10 @@ sh -n pmirror.sh            # syntax-only check
 
 `tests/f2-regression.sh` builds a fake origin tree and fake `phttpget`/`fetch` in a
 temp dir, then runs the mirror script through every case.
-Cases: a transfer that fails partway (`FAIL_OBJECT`), an origin that silently omits a
-requested object (`OMIT_OBJECT`), an origin serving an object under the wrong hash, a
-corrupt `f/` or `t/` object already published, a symlinked object, and an unchanged
-generation with and without clock skew. The first four must fail the run; the rest must
-succeed. There is no way to run a single case from the command line — edit the
+Cases include a transfer that fails partway (`FAIL_OBJECT`), an origin that silently
+omits a requested object (`OMIT_OBJECT`), invalid origin objects, corrupt published
+objects in every served class, symlinked objects, and an unchanged generation with and
+without clock skew. There is no way to run a single case from the command line — edit the
 `run_case` list at the bottom if you need to narrow it down. Run this suite for any change to the mirroring logic;
 it is the only check that exists.
 
@@ -49,15 +49,14 @@ tp/`, an empty `latest.ssl`, and a `robots.txt` that disallows everything).
 ## How a mirror run works
 
 Everything happens in a `mktemp -d` working directory. Downloads land in `STAGEDIR`, a
-mode-0700 `mktemp` directory created *inside* `${PUBDIR}` (`pmirror.sh:196-198`) so that
-installing a file is an atomic rename on the same filesystem. Both directories are
-removed by the `trap cleanup 0` handler (`pmirror.sh:70-81`) — that trap is why no stage
-needs its own unwind path.
+mode-0700 `mktemp` directory created *inside* `${PUBDIR}` so that installing a file is an
+atomic rename on the same filesystem. Both directories are removed by the
+`trap cleanup 0` handler — that trap is why no stage needs its own unwind path.
 
 1. **Control fetch.** `pub.ssl`, `snapshot.ssl`, `latest.ssl`. If `latest.ssl` matches
    the published copy, `LATEST_UNCHANGED=yes` and the run continues in verify-and-repair
-   mode: manifests are copied from `${PUBDIR}` instead of refetched, and the pruning and
-   publishing steps at the end are skipped (`pmirror.sh:453`). It does **not** exit
+   mode: manifests are copied from `${PUBDIR}` instead of refetched, object pruning still
+   runs, and only control-file publication is skipped. It does **not** exit
    early — a run against an unchanged generation still repairs missing or corrupt
    objects.
 2. **Per-category sync.** Binary patches (`bp/`), metadata files (`f/`), snapshots
@@ -68,23 +67,29 @@ needs its own unwind path.
 3. **Retention windows.** `LASTSNAP` is the newest timestamp in `bl`; cutoffs are
    relative to it — 86400s (1 day) for binary patches, files, and metadata patches,
    691200s (8 days) for metadata files. Tags are deliberately never pruned.
-4. **Fetch, install, verify.** `fetch_missing_files` checks phttpget's exit status
+4. **Fetch, scrub, install, verify.** `fetch_missing_files` checks phttpget's exit status
    separately from its filtered log and confirms each requested file actually landed in
-   the staging dir. `validate_content_addressed_files` gunzips (`f/`) or reads (`t/`)
-   each object and compares SHA-256 against its own filename, rejecting symlinks;
-   invalid objects are left out of the valid list so they get refetched. After
-   `install_staged_files`, `verify_required_files` plus a final validation pass must
-   account for every wanted object — `cmp -s f.wanted f.final.valid || exit 1`. The run
-   fails closed rather than publishing an incomplete generation.
-5. **Metadata patch generation** (`pmirror.sh:333-451`) — the expensive part. Patches the
+   the staging dir. `f/` and `t/` objects are checked directly against their SHA-256
+   filenames. `bp/` files are applied with `bspatch`, `tp/` diffs are applied with the
+   portsnap metadata algorithm, and `s/` archives are unpacked and verified against their
+   hashed `t/` metadata. Validation operates on private stable copies. Required invalid
+   objects stay published until an atomically installed repair has validated; invalid
+   unneeded hashed files and tags are then isolated in private staging. Snapshot archives
+   additionally reject links, special files, duplicate paths, and oversized archives or
+   inner objects.
+   The complete retained set is checked again before publication. Keep the protocol
+   validators aligned with the portsnap client.
+5. **Metadata patch generation** — the expensive part. Patches the
    mirror must serve are *generated locally*, not downloaded. Two embedded Perl programs:
    one diffs two sorted metadata files into `-`/`+` lines, the other composes existing
    `X→M` and `M→Y` patches into `X→Y` to avoid a full re-diff. Results ≥100000 bytes are
-   discarded rather than published.
-6. **Prune and publish** (skipped when unchanged). Obsolete objects are removed, then
-   `bl.gz`, `el.gz`, `tl.gz` and the three `.ssl` files are moved into `${PUBDIR}` last,
-   so `latest.ssl` only advances after everything it describes is in place. Preserve
-   that ordering.
+   discarded rather than published. Metadata patches are therefore best-effort: every
+   retained patch is validated, but an omitted patch over the size threshold is not a
+   mirror completeness failure because clients can fetch the full metadata object.
+6. **Prune and publish.** Obsolete objects are removed on every run. When the generation
+   changed, `bl.gz`, `el.gz`, `tl.gz` and the three `.ssl` files are moved into
+   `${PUBDIR}` last, so `latest.ssl` only advances after everything it describes is in
+   place. Preserve that ordering.
 
 ## Conventions
 
@@ -92,7 +97,7 @@ needs its own unwind path.
 - **Never pipe a `phttpget` or `fetch` invocation into `grep -v "200 OK" || true`.** That
   was the original upstream idiom and it discards the transfer's exit status, which is
   how incomplete generations got published. Capture output to a log, check the status,
-  then filter the log — see `fetch_missing_files` (`pmirror.sh:90-116`).
+  then filter the log — see `fetch_missing_files`.
 - `|| true` after `ls`-based list building is still intentional: it stops an empty `grep`
   result from tripping `-e`. Don't remove it as dead code.
 - The upstream BSD 2-clause header on the mirror scripts is Colin Percival's and must be

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ over HTTP, so `portsnap fetch` clients can be served from your own host.
 ## Requirements
 
 MidnightBSD or FreeBSD. The scripts use `/usr/libexec/phttpget`, `fetch`, `lam`,
-`sha256`, `perl`, and `lockf`, so they will not run unmodified on other systems.
+`sha256`, `bspatch`, `tar`, `perl`, and `lockf`, so they will not run unmodified on
+other systems.
 
 Budget roughly **1GB of disk** and **5GB/month of bandwidth** per mirror. Because
 portsnap's graceful-failure handling requires a mirror to carry large files it may never
@@ -30,13 +31,22 @@ crawling. Point your web server's document root at that directory.
 Runs are incremental, and every run also repairs. When the upstream `latest.ssl` is
 unchanged the script reuses the manifests it already published rather than refetching
 them, but it still confirms that every object the mirror is required to serve is present
-and that content-addressed files match their own SHA-256 name. Anything missing or
-corrupt is refetched; anything already valid is left alone.
+and valid, and prunes objects outside the signed retention set. Content-addressed files
+are checked against their SHA-256 names, binary and
+metadata patches are applied and checked against their target hashes, and snapshot
+archives are unpacked and verified against their hashed metadata. Required corrupt
+objects are replaced atomically after their repairs validate; invalid unneeded hashed
+files and tags are isolated in private staging and discarded when the run completes.
+Anything already valid is left alone. Binary-patch source objects are retained while
+their patches are retained so later scrubs remain self-contained.
 
 Downloads land in a private staging directory on the same filesystem and are only moved
 into the web root once verified, and the manifests and `.ssl` files are published last.
 A failed transfer aborts the run, so `latest.ssl` never advertises a generation the
 mirror cannot fully serve.
+Snapshot validation also rejects links, special files, duplicate members, and archives
+whose compressed, declared expanded, or per-object expanded size exceeds the safety
+limits in `pmirror.sh`.
 
 ### From cron
 
@@ -63,7 +73,8 @@ sh tests/f2-regression.sh
 The suite stubs out `phttpget` and `fetch` against a fake origin tree, so it needs no
 network and no portsnap server. It covers the failure
 modes that matter: a transfer that dies partway through, an origin that silently omits a
-requested object, and a corrupt file already sitting in the web root.
+requested object, invalid content from the origin, corrupt retained objects in every
+served object class, and symlinked publication entries.
 
 ## License
 

--- a/pmirror.sh
+++ b/pmirror.sh
@@ -87,6 +87,8 @@ BSPATCH=/usr/bin/bspatch
 SNAPSHOT_MAX_ARCHIVE_BYTES=268435456
 SNAPSHOT_MAX_EXPANDED_BYTES=1073741824
 OBJECT_MAX_EXPANDED_BYTES=67108864
+OBJECT_MAX_SOURCE_BYTES=67108864
+METADATA_PATCH_MAX_SOURCE_BYTES=100000
 
 # Bounded gzip expansion which requires the producer to reach a clean EOF.  The
 # FIFO lets POSIX sh preserve both command statuses without non-portable
@@ -125,6 +127,30 @@ hash_gzip_file () {
 	expand_gzip_file "${HASH_GZIP_SOURCE}" "${HASH_GZIP_OUTPUT}" \
 	    ${OBJECT_MAX_EXPANDED_BYTES} 65 || return 1
 	sha256 < "${HASH_GZIP_OUTPUT}"
+}
+
+# Read the signed little-endian target size from a BSDIFF40 header.  Reject
+# malformed and oversized declarations before bspatch can allocate its output.
+binary_patch_target_size () {
+	BINARY_PATCH_PATH=$1
+
+	if [ `wc -c < "${BINARY_PATCH_PATH}"` -lt 32 ] ||
+	    [ "`dd if="${BINARY_PATCH_PATH}" bs=1 count=8 2>/dev/null`" != \
+	    BSDIFF40 ]; then
+		return 1
+	fi
+	od -An -tu1 -j 24 -N 8 "${BINARY_PATCH_PATH}" 2>/dev/null |
+	    awk '
+	        NF != 8 { exit 1 }
+	        {
+	            value = $8 % 128
+	            for (i = 7; i >= 1; i--)
+	                value = value * 256 + $i
+	            if ($8 >= 128)
+	                value = -value
+	            printf "%.0f\n", value
+	        }
+	    '
 }
 
 # Fetch a list of missing files into the private staging directory.  Keep the
@@ -229,6 +255,16 @@ validation_path () {
 		echo "Unexpected ${VALIDATION_SUBDIR}/${VALIDATION_FILE} object type" >&2
 		return 2
 	fi
+	case ${VALIDATION_SUBDIR} in
+	s) VALIDATION_MAX_BYTES=${SNAPSHOT_MAX_ARCHIVE_BYTES} ;;
+	tp) VALIDATION_MAX_BYTES=${METADATA_PATCH_MAX_SOURCE_BYTES} ;;
+	*) VALIDATION_MAX_BYTES=${OBJECT_MAX_SOURCE_BYTES} ;;
+	esac
+	VALIDATION_SIZE=`wc -c < "${VALIDATION_SOURCE}"` || return 2
+	if [ ${VALIDATION_SIZE} -gt ${VALIDATION_MAX_BYTES} ]; then
+		echo "Oversized ${VALIDATION_SUBDIR}/${VALIDATION_FILE}" >&2
+		return 1
+	fi
 	if [ "${VALIDATION_BASE}" = "${STAGEDIR}" ]; then
 		echo "${VALIDATION_SOURCE}"
 		return 0
@@ -329,13 +365,24 @@ validate_binary_patches () {
 		VALIDATE_SOURCE=
 		VALIDATE_HASH=
 		VALIDATE_SOURCE=`find_valid_object f "${VALIDATE_FROM}.gz"` || true
+		VALIDATE_TARGET_SIZE=
+		if [ -n "${VALIDATE_PATH}" ]; then
+			VALIDATE_TARGET_SIZE=`binary_patch_target_size \
+			    "${VALIDATE_PATH}"` || true
+		fi
 		rm -f "${VALIDATE_OLD}" "${VALIDATE_NEW}"
 		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
 		    [ -n "${VALIDATE_SOURCE}" ] &&
-		    gunzip -c "${VALIDATE_SOURCE}" > "${VALIDATE_OLD}" &&
+		    [ -n "${VALIDATE_TARGET_SIZE}" ] &&
+		    [ ${VALIDATE_TARGET_SIZE} -ge 0 ] &&
+		    [ ${VALIDATE_TARGET_SIZE} -le ${OBJECT_MAX_EXPANDED_BYTES} ] &&
+		    expand_gzip_file "${VALIDATE_SOURCE}" "${VALIDATE_OLD}" \
+		    ${OBJECT_MAX_EXPANDED_BYTES} 65 &&
 		    ${BSPATCH} "${VALIDATE_OLD}" "${VALIDATE_NEW}" \
 		    "${VALIDATE_PATH}" >/dev/null 2>&1 &&
-		    [ -f "${VALIDATE_NEW}" ] && [ ! -L "${VALIDATE_NEW}" ]; then
+		    [ -f "${VALIDATE_NEW}" ] && [ ! -L "${VALIDATE_NEW}" ] &&
+		    [ `wc -c < "${VALIDATE_NEW}"` -eq \
+		    ${VALIDATE_TARGET_SIZE} ]; then
 			VALIDATE_HASH=`sha256 < "${VALIDATE_NEW}"`
 		fi
 		if [ "${VALIDATE_HASH}" = "${VALIDATE_TO}" ]; then
@@ -374,9 +421,10 @@ validate_metadata_patches () {
 		    "${VALIDATE_TMP}" "${VALIDATE_NEW}"
 		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
 		    [ -n "${VALIDATE_SOURCE}" ] &&
-		    gunzip -t "${VALIDATE_PATH}" 2>/dev/null &&
-		    gunzip -c "${VALIDATE_PATH}" > "${VALIDATE_DIFF}" &&
-		    gunzip -c "${VALIDATE_SOURCE}" > "${VALIDATE_OLD}"; then
+		    expand_gzip_file "${VALIDATE_PATH}" "${VALIDATE_DIFF}" \
+		    ${OBJECT_MAX_EXPANDED_BYTES} 65 &&
+		    expand_gzip_file "${VALIDATE_SOURCE}" "${VALIDATE_OLD}" \
+		    ${OBJECT_MAX_EXPANDED_BYTES} 65; then
 			cut -c 2- "${VALIDATE_DIFF}" |
 			    join -t '|' -v 2 - "${VALIDATE_OLD}" > "${VALIDATE_TMP}"
 			awk '/^\+/ { print substr($0, 2) }' "${VALIDATE_DIFF}" |

--- a/pmirror.sh
+++ b/pmirror.sh
@@ -83,6 +83,49 @@ trap 'exit 1' 1 2 15
 SERVER=$1
 PUBDIR=$2
 PHTTPGET="/usr/libexec/phttpget ${SERVER}"
+BSPATCH=/usr/bin/bspatch
+SNAPSHOT_MAX_ARCHIVE_BYTES=268435456
+SNAPSHOT_MAX_EXPANDED_BYTES=1073741824
+OBJECT_MAX_EXPANDED_BYTES=67108864
+
+# Bounded gzip expansion which requires the producer to reach a clean EOF.  The
+# FIFO lets POSIX sh preserve both command statuses without non-portable
+# pipefail.  COUNT is one MiB block beyond MAX_BYTES so oversize streams fail.
+expand_gzip_file () {
+	EXPAND_GZIP_SOURCE=$1
+	EXPAND_GZIP_OUTPUT=$2
+	EXPAND_GZIP_MAX_BYTES=$3
+	EXPAND_GZIP_COUNT=$4
+	EXPAND_GZIP_FIFO=${WRKDIR}/gzip.verify.fifo
+
+	rm -f "${EXPAND_GZIP_FIFO}" "${EXPAND_GZIP_OUTPUT}"
+	mkfifo "${EXPAND_GZIP_FIFO}"
+	gunzip -c "${EXPAND_GZIP_SOURCE}" > "${EXPAND_GZIP_FIFO}" 2>/dev/null &
+	EXPAND_GZIP_PID=$!
+	EXPAND_GZIP_DD_STATUS=0
+	dd if="${EXPAND_GZIP_FIFO}" of="${EXPAND_GZIP_OUTPUT}" \
+	    bs=1048576 count=${EXPAND_GZIP_COUNT} 2>/dev/null ||
+	    EXPAND_GZIP_DD_STATUS=$?
+	EXPAND_GZIP_STATUS=0
+	wait ${EXPAND_GZIP_PID} || EXPAND_GZIP_STATUS=$?
+	rm -f "${EXPAND_GZIP_FIFO}"
+	if [ ${EXPAND_GZIP_DD_STATUS} -ne 0 ] ||
+	    [ ${EXPAND_GZIP_STATUS} -ne 0 ] ||
+	    [ `wc -c < "${EXPAND_GZIP_OUTPUT}"` -gt \
+	    ${EXPAND_GZIP_MAX_BYTES} ]; then
+		return 1
+	fi
+	return 0
+}
+
+hash_gzip_file () {
+	HASH_GZIP_SOURCE=$1
+	HASH_GZIP_OUTPUT=$2
+
+	expand_gzip_file "${HASH_GZIP_SOURCE}" "${HASH_GZIP_OUTPUT}" \
+	    ${OBJECT_MAX_EXPANDED_BYTES} 65 || return 1
+	sha256 < "${HASH_GZIP_OUTPUT}"
+}
 
 # Fetch a list of missing files into the private staging directory.  Keep the
 # phttpget status separate from the filtered log output so a failed transfer
@@ -120,9 +163,38 @@ install_staged_files () {
 	INSTALL_MISSING=$2
 
 	while read INSTALL_FILE; do
-		mv "${STAGEDIR}/${INSTALL_SUBDIR}/${INSTALL_FILE}" \
-		    "${PUBDIR}/${INSTALL_SUBDIR}/${INSTALL_FILE}"
+		INSTALL_DEST=${PUBDIR}/${INSTALL_SUBDIR}/${INSTALL_FILE}
+		if [ -e "${INSTALL_DEST}" ] && [ ! -f "${INSTALL_DEST}" ] &&
+		    [ ! -L "${INSTALL_DEST}" ]; then
+			echo "Refusing to replace unexpected ${INSTALL_SUBDIR}/${INSTALL_FILE} object type" >&2
+			return 1
+		fi
+		mv -f "${STAGEDIR}/${INSTALL_SUBDIR}/${INSTALL_FILE}" \
+		    "${INSTALL_DEST}"
 	done < "${INSTALL_MISSING}"
+}
+
+quarantine_unrepaired_files () {
+	QUARANTINE_SUBDIR=$1
+	QUARANTINE_INVALID=$2
+	QUARANTINE_REPAIRED=$3
+	QUARANTINE_LIST=${WRKDIR}/${QUARANTINE_SUBDIR}.quarantine
+
+	comm -23 "${QUARANTINE_INVALID}" "${QUARANTINE_REPAIRED}" \
+	    > "${QUARANTINE_LIST}"
+	while read QUARANTINE_FILE; do
+		QUARANTINE_PATH=${PUBDIR}/${QUARANTINE_SUBDIR}/${QUARANTINE_FILE}
+		if [ -e "${QUARANTINE_PATH}" ] || [ -L "${QUARANTINE_PATH}" ]; then
+			if [ ! -f "${QUARANTINE_PATH}" ] &&
+			    [ ! -L "${QUARANTINE_PATH}" ]; then
+				echo "Refusing to quarantine unexpected ${QUARANTINE_SUBDIR}/${QUARANTINE_FILE} object type" >&2
+				return 1
+			fi
+			mkdir -p "${STAGEDIR}/quarantine/${QUARANTINE_SUBDIR}"
+			mv "${QUARANTINE_PATH}" \
+			    "${STAGEDIR}/quarantine/${QUARANTINE_SUBDIR}/${QUARANTINE_FILE}"
+		fi
+	done < "${QUARANTINE_LIST}"
 }
 
 verify_required_files () {
@@ -137,6 +209,57 @@ verify_required_files () {
 	done < "${VERIFY_WANTED}"
 }
 
+# Return a stable, private copy for validation.  Published files are never
+# moved aside before a validated replacement is ready: installation atomically
+# replaces a regular file or symlink, while a failed run leaves publication
+# unchanged.  Unexpected node types are an operator error and abort the run.
+validation_path () {
+	VALIDATION_BASE=$1
+	VALIDATION_SUBDIR=$2
+	VALIDATION_FILE=$3
+	VALIDATION_SOURCE=${VALIDATION_BASE}/${VALIDATION_SUBDIR}/${VALIDATION_FILE}
+
+	if [ ! -e "${VALIDATION_SOURCE}" ] && [ ! -L "${VALIDATION_SOURCE}" ]; then
+		return 1
+	fi
+	if [ -L "${VALIDATION_SOURCE}" ]; then
+		return 1
+	fi
+	if [ ! -f "${VALIDATION_SOURCE}" ]; then
+		echo "Unexpected ${VALIDATION_SUBDIR}/${VALIDATION_FILE} object type" >&2
+		return 2
+	fi
+	if [ "${VALIDATION_BASE}" = "${STAGEDIR}" ]; then
+		echo "${VALIDATION_SOURCE}"
+		return 0
+	fi
+	if ! mkdir -p "${STAGEDIR}/scrub/${VALIDATION_SUBDIR}"; then
+		return 2
+	fi
+	VALIDATION_COPY=${STAGEDIR}/scrub/${VALIDATION_SUBDIR}/${VALIDATION_FILE}
+	if ! cp "${VALIDATION_SOURCE}" "${VALIDATION_COPY}"; then
+		return 2
+	fi
+	echo "${VALIDATION_COPY}"
+}
+
+find_valid_object () {
+	FIND_SUBDIR=$1
+	FIND_FILE=$2
+
+	if [ -f "${STAGEDIR}/${FIND_SUBDIR}/${FIND_FILE}" ] &&
+	    [ ! -L "${STAGEDIR}/${FIND_SUBDIR}/${FIND_FILE}" ]; then
+		echo "${STAGEDIR}/${FIND_SUBDIR}/${FIND_FILE}"
+		return 0
+	fi
+	if [ -f "${STAGEDIR}/scrub/${FIND_SUBDIR}/${FIND_FILE}" ] &&
+	    [ ! -L "${STAGEDIR}/scrub/${FIND_SUBDIR}/${FIND_FILE}" ]; then
+		echo "${STAGEDIR}/scrub/${FIND_SUBDIR}/${FIND_FILE}"
+		return 0
+	fi
+	return 1
+}
+
 # The publication directory must be writable only by the mirror operator.
 # Reject symlinks and validate content-addressed objects before treating an
 # existing object as usable.  Invalid objects are omitted from the valid list
@@ -149,14 +272,19 @@ validate_content_addressed_files () {
 
 	: > "${VALIDATE_VALID}"
 	while read VALIDATE_FILE; do
-		VALIDATE_PATH=${VALIDATE_BASE}/${VALIDATE_SUBDIR}/${VALIDATE_FILE}
+		VALIDATE_PATH=`validation_path "${VALIDATE_BASE}" \
+		    "${VALIDATE_SUBDIR}" "${VALIDATE_FILE}"` || {
+			VALIDATE_STATUS=$?
+			if [ ${VALIDATE_STATUS} -eq 2 ]; then return 1; fi
+			VALIDATE_PATH=
+		}
 		VALIDATE_HASH=
 		case ${VALIDATE_SUBDIR} in
 		f)
 			if [ -f "${VALIDATE_PATH}" ] &&
-			    [ ! -L "${VALIDATE_PATH}" ] &&
-			    gunzip -t "${VALIDATE_PATH}" 2>/dev/null; then
-				VALIDATE_HASH=`gunzip -c "${VALIDATE_PATH}" | sha256`
+			    [ ! -L "${VALIDATE_PATH}" ]; then
+				VALIDATE_HASH=`hash_gzip_file "${VALIDATE_PATH}" \
+				    "${WRKDIR}/f.verify.uncompressed"` || true
 			fi
 			VALIDATE_EXPECTED=${VALIDATE_FILE%.gz}
 			;;
@@ -181,6 +309,182 @@ validate_content_addressed_files () {
 	done < "${VALIDATE_WANTED}"
 }
 
+validate_binary_patches () {
+	VALIDATE_BASE=$1
+	VALIDATE_WANTED=$2
+	VALIDATE_VALID=$3
+	VALIDATE_OLD=${WRKDIR}/bp.verify.old
+	VALIDATE_NEW=${WRKDIR}/bp.verify.new
+
+	: > "${VALIDATE_VALID}"
+	while read VALIDATE_FILE; do
+		VALIDATE_PATH=`validation_path "${VALIDATE_BASE}" bp \
+		    "${VALIDATE_FILE}"` || {
+			VALIDATE_STATUS=$?
+			if [ ${VALIDATE_STATUS} -eq 2 ]; then return 1; fi
+			VALIDATE_PATH=
+		}
+		VALIDATE_FROM=${VALIDATE_FILE%-*}
+		VALIDATE_TO=${VALIDATE_FILE#*-}
+		VALIDATE_SOURCE=
+		VALIDATE_HASH=
+		VALIDATE_SOURCE=`find_valid_object f "${VALIDATE_FROM}.gz"` || true
+		rm -f "${VALIDATE_OLD}" "${VALIDATE_NEW}"
+		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
+		    [ -n "${VALIDATE_SOURCE}" ] &&
+		    gunzip -c "${VALIDATE_SOURCE}" > "${VALIDATE_OLD}" &&
+		    ${BSPATCH} "${VALIDATE_OLD}" "${VALIDATE_NEW}" \
+		    "${VALIDATE_PATH}" >/dev/null 2>&1 &&
+		    [ -f "${VALIDATE_NEW}" ] && [ ! -L "${VALIDATE_NEW}" ]; then
+			VALIDATE_HASH=`sha256 < "${VALIDATE_NEW}"`
+		fi
+		if [ "${VALIDATE_HASH}" = "${VALIDATE_TO}" ]; then
+			echo "${VALIDATE_FILE}" >> "${VALIDATE_VALID}"
+		else
+			echo "Invalid bp/${VALIDATE_FILE}" >&2
+		fi
+	done < "${VALIDATE_WANTED}"
+	rm -f "${VALIDATE_OLD}" "${VALIDATE_NEW}"
+}
+
+validate_metadata_patches () {
+	VALIDATE_BASE=$1
+	VALIDATE_WANTED=$2
+	VALIDATE_VALID=$3
+	VALIDATE_DIFF=${WRKDIR}/tp.verify.diff
+	VALIDATE_OLD=${WRKDIR}/tp.verify.old
+	VALIDATE_TMP=${WRKDIR}/tp.verify.tmp
+	VALIDATE_NEW=${WRKDIR}/tp.verify.new
+
+	: > "${VALIDATE_VALID}"
+	while read VALIDATE_FILE; do
+		VALIDATE_PATH=`validation_path "${VALIDATE_BASE}" tp \
+		    "${VALIDATE_FILE}"` || {
+			VALIDATE_STATUS=$?
+			if [ ${VALIDATE_STATUS} -eq 2 ]; then return 1; fi
+			VALIDATE_PATH=
+		}
+		VALIDATE_PAIR=${VALIDATE_FILE%.gz}
+		VALIDATE_FROM=${VALIDATE_PAIR%-*}
+		VALIDATE_TO=${VALIDATE_PAIR#*-}
+		VALIDATE_SOURCE=
+		VALIDATE_HASH=
+		VALIDATE_SOURCE=`find_valid_object f "${VALIDATE_FROM}.gz"` || true
+		rm -f "${VALIDATE_DIFF}" "${VALIDATE_OLD}" \
+		    "${VALIDATE_TMP}" "${VALIDATE_NEW}"
+		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
+		    [ -n "${VALIDATE_SOURCE}" ] &&
+		    gunzip -t "${VALIDATE_PATH}" 2>/dev/null &&
+		    gunzip -c "${VALIDATE_PATH}" > "${VALIDATE_DIFF}" &&
+		    gunzip -c "${VALIDATE_SOURCE}" > "${VALIDATE_OLD}"; then
+			cut -c 2- "${VALIDATE_DIFF}" |
+			    join -t '|' -v 2 - "${VALIDATE_OLD}" > "${VALIDATE_TMP}"
+			awk '/^\+/ { print substr($0, 2) }' "${VALIDATE_DIFF}" |
+			    sort -k 1,1 -t '|' -m - "${VALIDATE_TMP}" \
+			    > "${VALIDATE_NEW}"
+			VALIDATE_HASH=`sha256 < "${VALIDATE_NEW}"`
+		fi
+		if [ "${VALIDATE_HASH}" = "${VALIDATE_TO}" ]; then
+			echo "${VALIDATE_FILE}" >> "${VALIDATE_VALID}"
+		else
+			echo "Invalid tp/${VALIDATE_FILE}" >&2
+		fi
+	done < "${VALIDATE_WANTED}"
+	rm -f "${VALIDATE_DIFF}" "${VALIDATE_OLD}" \
+	    "${VALIDATE_TMP}" "${VALIDATE_NEW}"
+}
+
+validate_snapshots () {
+	VALIDATE_BASE=$1
+	VALIDATE_WANTED=$2
+	VALIDATE_VALID=$3
+	VALIDATE_DIR=${WRKDIR}/snapshot.verify
+
+	: > "${VALIDATE_VALID}"
+	while read VALIDATE_FILE; do
+		VALIDATE_PATH=`validation_path "${VALIDATE_BASE}" s \
+		    "${VALIDATE_FILE}"` || {
+			VALIDATE_STATUS=$?
+			if [ ${VALIDATE_STATUS} -eq 2 ]; then return 1; fi
+			VALIDATE_PATH=
+		}
+		VALIDATE_TAG_HASH=${VALIDATE_FILE%.tgz}
+		VALIDATE_TAG=
+		VALIDATE_TAG=`find_valid_object t "${VALIDATE_TAG_HASH}"` || true
+		rm -rf "${VALIDATE_DIR}"
+		mkdir -p "${VALIDATE_DIR}"
+		VALIDATE_OK=no
+		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
+		    [ `wc -c < "${VALIDATE_PATH}"` -le \
+		    ${SNAPSHOT_MAX_ARCHIVE_BYTES} ] &&
+		    expand_gzip_file "${VALIDATE_PATH}" \
+		    "${VALIDATE_DIR}/snapshot.tar" \
+		    ${SNAPSHOT_MAX_EXPANDED_BYTES} 1025 &&
+		    [ -n "${VALIDATE_TAG}" ] &&
+		    ! grep -qvE '^[0-9A-Z.]+\|[0-9a-f]{64}$' "${VALIDATE_TAG}" &&
+		    [ `grep '^INDEX|' "${VALIDATE_TAG}" | wc -l` -eq 1 ] &&
+		    tar -tf "${VALIDATE_DIR}/snapshot.tar" \
+		    > "${VALIDATE_DIR}/members" 2>/dev/null &&
+		    [ `sort "${VALIDATE_DIR}/members" | uniq -d | wc -l` -eq 0 ] &&
+		    ! grep -qvE '^snap/([0-9a-f]{64}\.gz)?$' \
+		    "${VALIDATE_DIR}/members" &&
+		    tar -tvf "${VALIDATE_DIR}/snapshot.tar" \
+		    > "${VALIDATE_DIR}/members.verbose" 2>/dev/null &&
+		    ! grep -qvE '^[-d]' "${VALIDATE_DIR}/members.verbose" &&
+		    ! grep -Eq ' (link to|->) ' "${VALIDATE_DIR}/members.verbose" &&
+		    awk -v max=${SNAPSHOT_MAX_EXPANDED_BYTES} '
+		        $2 ~ /^[0-9]+$/ { size = $5 }
+		        $2 !~ /^[0-9]+$/ { size = $3 }
+		        size !~ /^[0-9]+$/ { exit 1 }
+		        { total += size; if (total > max) exit 1 }
+		    ' "${VALIDATE_DIR}/members.verbose"; then
+			VALIDATE_INDEX_HASH=`grep '^INDEX|' "${VALIDATE_TAG}" |
+			    cut -f 2 -d '|'`
+			if tar -xf "${VALIDATE_DIR}/snapshot.tar" -C "${VALIDATE_DIR}" \
+			    --no-same-owner --no-same-permissions >/dev/null 2>&1 &&
+			    [ -f "${VALIDATE_DIR}/snap/${VALIDATE_INDEX_HASH}.gz" ] &&
+			    [ ! -L "${VALIDATE_DIR}/snap/${VALIDATE_INDEX_HASH}.gz" ] &&
+			    [ `hash_gzip_file \
+			    "${VALIDATE_DIR}/snap/${VALIDATE_INDEX_HASH}.gz" \
+			    "${VALIDATE_DIR}/INDEX"` = "${VALIDATE_INDEX_HASH}" ]; then
+				if ! grep -qvE '^[-_+./@0-9A-Za-z]+\|[0-9a-f]{64}$' \
+				    "${VALIDATE_DIR}/INDEX" &&
+				    ! fgrep -q './' "${VALIDATE_DIR}/INDEX"; then
+					cut -f 2 -d '|' "${VALIDATE_TAG}" \
+					    "${VALIDATE_DIR}/INDEX" | sort -u \
+					    > "${VALIDATE_DIR}/hashes"
+					lam -s 'snap/' "${VALIDATE_DIR}/hashes" \
+					    -s '.gz' > "${VALIDATE_DIR}/expected"
+					find "${VALIDATE_DIR}/snap" -mindepth 1 |
+					    sed "s#^${VALIDATE_DIR}/##" | sort \
+					    > "${VALIDATE_DIR}/actual"
+					if cmp -s "${VALIDATE_DIR}/expected" \
+					    "${VALIDATE_DIR}/actual"; then
+						VALIDATE_OK=yes
+						while read VALIDATE_HASH; do
+							VALIDATE_OBJECT=${VALIDATE_DIR}/snap/${VALIDATE_HASH}.gz
+							if ! [ -f "${VALIDATE_OBJECT}" ] ||
+							    [ -L "${VALIDATE_OBJECT}" ] ||
+							    ! [ `hash_gzip_file "${VALIDATE_OBJECT}" \
+							    "${VALIDATE_DIR}/object"` = \
+							    "${VALIDATE_HASH}" ]; then
+								VALIDATE_OK=no
+								break
+							fi
+						done < "${VALIDATE_DIR}/hashes"
+					fi
+				fi
+			fi
+		fi
+		if [ "${VALIDATE_OK}" = yes ]; then
+			echo "${VALIDATE_FILE}" >> "${VALIDATE_VALID}"
+		else
+			echo "Invalid s/${VALIDATE_FILE}" >&2
+		fi
+	done < "${VALIDATE_WANTED}"
+	rm -rf "${VALIDATE_DIR}"
+}
+
 export HTTP_USER_AGENT="pmirror/0.9"
 
 # If ${PUBDIR}/pub.ssl does not exist, assume we have an empty
@@ -197,7 +501,7 @@ fi
 # the publication filesystem.  mktemp creates this directory mode 0700.
 STAGEDIR=`mktemp -d "${PUBDIR}/.pmirror-stage.XXXXXX"` || exit 1
 mkdir -p "${STAGEDIR}/bp" "${STAGEDIR}/f" \
-	"${STAGEDIR}/s" "${STAGEDIR}/t"
+	"${STAGEDIR}/s" "${STAGEDIR}/t" "${STAGEDIR}/tp"
 
 if ! ${PHTTPGET} pub.ssl snapshot.ssl latest.ssl > control.fetch.log 2>&1; then
 	grep -v "200 OK" control.fetch.log || true
@@ -229,12 +533,9 @@ awk -F \| -v cutoff=`expr ${LASTSNAP} - 86400`		\
 	'{ if ($2 > cutoff) { print } }' bl |
 	join -t '|' bl - |
 	awk -F \| '{ if ($4 > $2) { print $3 "-" $5 } }' |
-	sort | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}$' > bp.wanted
+	sort -u | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}$' > bp.wanted
 ( cd ${PUBDIR}/bp/ && ls ) |
 	grep -E '^[0-9a-f]{64}-[0-9a-f]{64}$' > bp.present || true
-echo "`date`: Fetching needed binary patches"
-comm -13 bp.present bp.wanted > bp.missing
-fetch_missing_files bp bp.missing
 
 echo "`date`: Fetching metadata files list"
 rm -f tl.gz tl
@@ -253,16 +554,27 @@ awk -F \| -v cutoff=`expr ${LASTSNAP} - 86400`		\
 awk -F \| -v cutoff=`expr ${LASTSNAP} - 691200`		\
 	'{ if ($2 > cutoff) { print $3 ".gz" } }' tl |
 	grep -E '^[0-9a-f]{64}\.gz$' >> f.wanted || true
-sort f.wanted > f.wanted.tmp
+tr '-' '\n' < bp.wanted | sed 's/$/.gz/' |
+	grep -E '^[0-9a-f]{64}\.gz$' >> f.wanted || true
+sort -u f.wanted > f.wanted.tmp
 mv f.wanted.tmp f.wanted
 ( cd ${PUBDIR}/f/ && ls ) |
 	grep -E '^[0-9a-f]{64}\.gz$' > f.present || true
-validate_content_addressed_files "${PUBDIR}" f f.wanted f.valid
+validate_content_addressed_files "${PUBDIR}" f f.present f.present.valid
+comm -23 f.present f.present.valid > f.invalid
 echo "`date`: Fetching needed files"
-comm -13 f.valid f.wanted > f.missing
+comm -13 f.present.valid f.wanted > f.missing
 fetch_missing_files f f.missing
 validate_content_addressed_files "${STAGEDIR}" f f.missing f.staged.valid
 cmp -s f.missing f.staged.valid || exit 1
+
+echo "`date`: Verifying and fetching needed binary patches"
+comm -12 bp.present bp.wanted > bp.scrub
+validate_binary_patches "${PUBDIR}" bp.scrub bp.present.valid
+comm -13 bp.present.valid bp.wanted > bp.missing
+fetch_missing_files bp bp.missing
+validate_binary_patches "${STAGEDIR}" bp.missing bp.staged.valid
+cmp -s bp.missing bp.staged.valid || exit 1
 
 echo "`date`: Fetching extra files list"
 rm -f el.gz el
@@ -274,32 +586,39 @@ fi
 [ -f el.gz ] || exit 1
 gunzip -c el.gz > el
 
-echo "`date`: Constructing list of snapshots wanted"
-grep -E '^s/' el | cut -f 2 -d '/' |
-	sort | grep -E '^[0-9a-f]{64}\.tgz$' > s.wanted || true
-( cd ${PUBDIR}/s/ && ls ) |
-	grep -E '^[0-9a-f]{64}\.tgz$' > s.present || true
-echo "`date`: Fetching needed snapshots"
-comm -13 s.present s.wanted > s.missing
-fetch_missing_files s s.missing
-
 echo "`date`: Constructing list of tags wanted"
 grep -E '^t/' el | cut -f 2 -d '/' |
-	sort | grep -E '^[0-9a-f]{64}$' > t.wanted || true
+	sort -u | grep -E '^[0-9a-f]{64}$' > t.wanted || true
 ( cd ${PUBDIR}/t/ && ls ) |
 	grep -E '^[0-9a-f]{64}$' > t.present || true
-validate_content_addressed_files "${PUBDIR}" t t.wanted t.valid
+validate_content_addressed_files "${PUBDIR}" t t.present t.present.valid
+comm -23 t.present t.present.valid > t.invalid
 echo "`date`: Fetching needed tags"
-comm -13 t.valid t.wanted > t.missing
+comm -13 t.present.valid t.wanted > t.missing
 fetch_missing_files t t.missing
 validate_content_addressed_files "${STAGEDIR}" t t.missing t.staged.valid
 cmp -s t.missing t.staged.valid || exit 1
+
+echo "`date`: Constructing list of snapshots wanted"
+grep -E '^s/' el | cut -f 2 -d '/' |
+	sort -u | grep -E '^[0-9a-f]{64}\.tgz$' > s.wanted || true
+( cd ${PUBDIR}/s/ && ls ) |
+	grep -E '^[0-9a-f]{64}\.tgz$' > s.present || true
+echo "`date`: Verifying and fetching needed snapshots"
+comm -12 s.present s.wanted > s.scrub
+validate_snapshots "${PUBDIR}" s.scrub s.present.valid
+comm -13 s.present.valid s.wanted > s.missing
+fetch_missing_files s s.missing
+validate_snapshots "${STAGEDIR}" s.missing s.staged.valid
+cmp -s s.missing s.staged.valid || exit 1
 
 echo "`date`: Installing and verifying needed files"
 install_staged_files bp bp.missing
 install_staged_files f f.missing
 install_staged_files s s.missing
 install_staged_files t t.missing
+quarantine_unrepaired_files f f.invalid f.missing
+quarantine_unrepaired_files t t.invalid t.missing
 verify_required_files bp bp.wanted
 verify_required_files f f.wanted
 verify_required_files s s.wanted
@@ -308,6 +627,10 @@ validate_content_addressed_files "${PUBDIR}" f f.wanted f.final.valid
 cmp -s f.wanted f.final.valid || exit 1
 validate_content_addressed_files "${PUBDIR}" t t.wanted t.final.valid
 cmp -s t.wanted t.final.valid || exit 1
+validate_binary_patches "${PUBDIR}" bp.wanted bp.final.valid
+cmp -s bp.wanted bp.final.valid || exit 1
+validate_snapshots "${PUBDIR}" s.wanted s.final.valid
+cmp -s s.wanted s.final.valid || exit 1
 
 # Don't bother deleting old tag files.  They don't take up any
 # significant space, and keeping them is useful for statistical
@@ -320,15 +643,18 @@ awk -F \| -v cutoff=`expr ${LASTSNAP} - 86400`		\
 	'{ if ($2 > cutoff) { print } }' tl |
 	join -t '|' tl - |
 	awk -F \| '{ if ($4 > $2) { print $3 "-" $5 ".gz" } }' |
-	sort | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.wanted || true
+	sort -u | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.wanted || true
 awk -F \| -v cutoff=`expr ${LASTSNAP} - 86400`		\
 	'{ if ($2 > cutoff) { print } }' tl |
 	join -t '|' tl - |
 	fgrep "|${LASTSNAP}|" |
 	awk -F \| '{ if ($4 > $2) { print $3 "-" $5 ".gz" } }' |
-	sort | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.needed || true
+	sort -u | grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.needed || true
 ( cd ${PUBDIR}/tp/ && ls ) |
 	grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.present || true
+comm -12 tp.present tp.wanted > tp.scrub
+validate_metadata_patches "${PUBDIR}" tp.scrub tp.present.valid
+comm -23 tp.scrub tp.present.valid > tp.invalid
 
 echo "`date`: Generating needed metadata patches"
 # This generates lines of the form RECENTHASH|OLDHASH|NEWHASH,
@@ -342,7 +668,7 @@ echo "`date`: Generating needed metadata patches"
 
 sort -k 3 -t '|' tl > tl.sorted
 
-cut -f 1 -d '.' f.present |
+cut -f 1 -d '.' f.final.valid |
 	join -2 3 -t '|' - tl.sorted |
 	sort -k 3 -t '|' |
 	perl -e '
@@ -354,7 +680,8 @@ cut -f 1 -d '.' f.present |
 			print "$f|$l{$f}\n"
 		}' > metadata.latest
 
-comm -13 tp.present tp.needed |
+: > tp.generated
+comm -13 tp.present.valid tp.needed |
 	cut -f 1 -d '.' |
 	tr '-' '|' |
 	join -o 1.1,1.2,2.1,2.2 -1 3 -t '|' tl.sorted - |
@@ -367,10 +694,12 @@ while read LINE; do
 	Y=`echo ${LINE} | cut -f 3 -d '|'`
 	M=`echo ${LINE} | cut -f 1 -d '|'`
 
-	if [ ! -f "${PUBDIR}/tp/${X}-${M}.gz" ] ||
-	    [ ! -f "${PUBDIR}/tp/${M}-${Y}.gz" ]; then
-		gunzip -c < ${PUBDIR}/f/${X}.gz | sort > ${X}
-		gunzip -c < ${PUBDIR}/f/${Y}.gz | sort > ${Y}
+	if ! grep -Fqx "${X}-${M}.gz" tp.present.valid ||
+	    ! grep -Fqx "${M}-${Y}.gz" tp.present.valid; then
+		X_SOURCE=`find_valid_object f "${X}.gz"` || exit 1
+		Y_SOURCE=`find_valid_object f "${Y}.gz"` || exit 1
+		gunzip -c "${X_SOURCE}" | sort > ${X}
+		gunzip -c "${Y_SOURCE}" | sort > ${Y}
 		perl -e '
 			open F, $ARGV[0];
 			open G, $ARGV[1];
@@ -392,9 +721,11 @@ while read LINE; do
 			sort -k 1.2,1 -t '|' > ${X}-${Y}
 		rm ${X} ${Y}
 	else
-		gunzip -c "${PUBDIR}/tp/${X}-${M}.gz" | sort -r |
+		XM_SOURCE=`find_valid_object tp "${X}-${M}.gz"` || exit 1
+		MY_SOURCE=`find_valid_object tp "${M}-${Y}.gz"` || exit 1
+		gunzip -c "${XM_SOURCE}" | sort -r |
 			sort -s -k 1.2,1 -t '|' > ${X}-${M}
-		gunzip -c "${PUBDIR}/tp/${M}-${Y}.gz" | sort -r |
+		gunzip -c "${MY_SOURCE}" | sort -r |
 			sort -s -k 1.2,1 -t '|' > ${M}-${Y}
 		perl -e '
 			open F, $ARGV[0];
@@ -445,23 +776,57 @@ while read LINE; do
 
 	gzip -9n ${X}-${Y}
 	if [ `wc -c < ${X}-${Y}.gz` -lt 100000 ]; then
-		mv ${X}-${Y}.gz ${PUBDIR}/tp/
+		mv ${X}-${Y}.gz ${STAGEDIR}/tp/
+		echo "${X}-${Y}.gz" >> tp.generated
 	else
 		rm ${X}-${Y}.gz
 	fi
 done
 
+sort -u tp.generated > tp.generated.sorted
+mv tp.generated.sorted tp.generated
+validate_metadata_patches "${STAGEDIR}" tp.generated tp.staged.valid
+cmp -s tp.generated tp.staged.valid || exit 1
+install_staged_files tp tp.generated
+# Invalid optional patches which could not be regenerated under the size policy
+# are removed only after every staged repair has validated.
+comm -23 tp.invalid tp.generated > tp.remove
+while read TP_REMOVE; do
+	TP_REMOVE_PATH=${PUBDIR}/tp/${TP_REMOVE}
+	if [ -e "${TP_REMOVE_PATH}" ] || [ -L "${TP_REMOVE_PATH}" ]; then
+		if [ ! -f "${TP_REMOVE_PATH}" ] && [ ! -L "${TP_REMOVE_PATH}" ]; then
+			echo "Refusing to remove unexpected tp/${TP_REMOVE} object type" >&2
+			exit 1
+		fi
+		mkdir -p "${STAGEDIR}/quarantine/tp"
+		mv "${TP_REMOVE_PATH}" "${STAGEDIR}/quarantine/tp/${TP_REMOVE}"
+	fi
+done < tp.remove
+( cd ${PUBDIR}/tp/ && ls ) |
+	grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.retained || true
+comm -12 tp.retained tp.wanted > tp.final
+validate_metadata_patches "${PUBDIR}" tp.final tp.final.valid
+cmp -s tp.final tp.final.valid || exit 1
+
+echo "`date`: Removing unneeded metadata patches"
+( cd ${PUBDIR}/tp/ && ls ) |
+	grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' > tp.prune || true
+comm -23 tp.prune tp.wanted | ( cd ${PUBDIR}/tp/ && xargs rm )
+
+echo "`date`: Removing unneeded binary patches"
+( cd ${PUBDIR}/bp/ && ls ) |
+	grep -E '^[0-9a-f]{64}-[0-9a-f]{64}$' > bp.prune || true
+comm -23 bp.prune bp.wanted | ( cd ${PUBDIR}/bp/ && xargs rm )
+echo "`date`: Removing unneeded files"
+( cd ${PUBDIR}/f/ && ls ) |
+	grep -E '^[0-9a-f]{64}\.gz$' > f.prune || true
+comm -23 f.prune f.wanted | ( cd ${PUBDIR}/f/ && xargs rm )
+echo "`date`: Removing unneeded snapshots"
+( cd ${PUBDIR}/s/ && ls ) |
+	grep -E '^[0-9a-f]{64}\.tgz$' > s.prune || true
+comm -23 s.prune s.wanted | ( cd ${PUBDIR}/s/ && xargs rm )
+
 if [ ${LATEST_UNCHANGED} = no ]; then
-	echo "`date`: Removing unneeded metadata patches"
-	comm -23 tp.present tp.wanted | ( cd ${PUBDIR}/tp/ && xargs rm )
-
-	echo "`date`: Removing unneeded binary patches"
-	comm -23 bp.present bp.wanted | ( cd ${PUBDIR}/bp/ && xargs rm )
-	echo "`date`: Removing unneeded files"
-	comm -23 f.present f.wanted | ( cd ${PUBDIR}/f/ && xargs rm )
-	echo "`date`: Removing unneeded snapshots"
-	comm -23 s.present s.wanted | ( cd ${PUBDIR}/s/ && xargs rm )
-
 	echo "`date`: Publishing file lists and signatures"
 	mv bl.gz el.gz tl.gz ${PUBDIR}
 	mv latest.ssl pub.ssl snapshot.ssl ${PUBDIR}
@@ -469,14 +834,20 @@ else
 	rm bl.gz el.gz tl.gz latest.ssl pub.ssl snapshot.ssl
 fi
 
+rm -f bp.prune f.prune s.prune tp.prune
+
 echo "`date`: Removing temporary files"
 rm bl el tl
 rm tl.sorted metadata.latest
-rm bp.wanted bp.present
-rm bp.missing
-rm f.wanted f.present f.valid f.missing f.staged.valid f.final.valid
-rm s.present s.wanted s.missing
-rm t.present t.wanted t.valid t.missing t.staged.valid t.final.valid
-rm tp.present tp.wanted tp.needed
+rm bp.wanted bp.present bp.scrub bp.present.valid bp.missing bp.staged.valid
+rm bp.final.valid
+rm f.wanted f.present f.present.valid f.invalid f.quarantine f.missing f.staged.valid
+rm f.final.valid
+rm s.present s.scrub s.present.valid s.wanted s.missing s.staged.valid
+rm s.final.valid
+rm t.present t.present.valid t.invalid t.quarantine t.wanted t.missing t.staged.valid
+rm t.final.valid
+rm tp.present tp.present.valid tp.wanted tp.needed tp.generated
+rm tp.scrub tp.invalid tp.remove tp.staged.valid tp.retained tp.final tp.final.valid
 
 # Temporary and staging directories are removed by the exit trap.

--- a/tests/f2-regression.sh
+++ b/tests/f2-regression.sh
@@ -80,10 +80,12 @@ EOF
 
 cat > "${TEST_BINDIR}/bspatch" <<'EOF'
 #!/bin/sh
-TEST_EXPECTED=`sed -n '1p' "$3"`
+dd if="$3" of="${3}.payload" bs=1 skip=32 2>/dev/null
+TEST_EXPECTED=`sed -n '1p' "${3}.payload"`
 TEST_ACTUAL=`sha256sum "$1" | awk '{ print $1 }'`
 [ "${TEST_ACTUAL}" = "${TEST_EXPECTED}" ] || exit 1
-sed '1d' "$3" > "$2"
+sed '1d' "${3}.payload" > "$2"
+rm "${3}.payload"
 EOF
 
 chmod +x "${TEST_BINDIR}/phttpget" "${TEST_BINDIR}/fetch" \
@@ -136,10 +138,15 @@ run_case () {
 	printf 'public key\n' > "${TEST_ORIGIN}/pub.ssl"
 	printf 'snapshot signature\n' > "${TEST_ORIGIN}/snapshot.ssl"
 	printf 'new signature\n' > "${TEST_ORIGIN}/latest.ssl"
-	printf '%s\n' "${TEST_OLD_HASH}" \
+	TEST_BP_SIZE=`wc -c < "${TEST_CASE}/INDEX.new"`
+	( printf 'BSDIFF40'
+	  printf '\000\000\000\000\000\000\000\000'
+	  printf '\000\000\000\000\000\000\000\000'
+	  printf "\\`printf '%03o' ${TEST_BP_SIZE}`"
+	  printf '\000\000\000\000\000\000\000'
+	  printf '%s\n' "${TEST_OLD_HASH}"
+	  sed -n '1,$p' "${TEST_CASE}/INDEX.new" ) \
 		> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
-	sed -n '1,$p' "${TEST_CASE}/INDEX.new" \
-		>> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
 	mkdir -p "${TEST_CASE}/snapshot/snap"
 	gzip -c "${TEST_CASE}/INDEX.new" \
 		> "${TEST_CASE}/snapshot/snap/${TEST_HASH}.gz"
@@ -176,6 +183,13 @@ run_case () {
 		printf 'invalid binary patch\n' \
 			> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
 	fi
+	if [ "${TEST_MODE}" = bad-bp-target-size ]; then
+		( printf 'BSDIFF40'
+		  printf '\000\000\000\000\000\000\000\000'
+		  printf '\000\000\000\000\000\000\000\000'
+		  printf '\001\000\000\004\000\000\000\000' ) \
+			> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+	fi
 	if [ "${TEST_MODE}" = bad-snapshot ]; then
 		printf 'corrupt archived file\n' | gzip -c \
 			> "${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
@@ -199,7 +213,7 @@ run_case () {
 	fi
 
 	case ${TEST_MODE} in
-	unchanged|unchanged-skew|unchanged-extra|corrupt-existing-f|corrupt-existing-t|corrupt-existing-bp|corrupt-existing-s|corrupt-existing-tp|corrupt-existing-tp-source|failed-repair-preserves-existing|directory-existing|symlink-existing)
+	unchanged|unchanged-skew|unchanged-extra|corrupt-existing-f|oversized-existing-f|corrupt-existing-t|corrupt-existing-bp|corrupt-existing-s|corrupt-existing-tp|corrupt-existing-tp-source|corrupt-existing-tp-bomb|failed-repair-preserves-existing|directory-existing|symlink-existing)
 		printf 'new signature\n' > "${TEST_PUBDIR}/latest.ssl"
 		cp "${TEST_ORIGIN}/bl.gz" "${TEST_PUBDIR}/bl.gz"
 		cp "${TEST_ORIGIN}/tl.gz" "${TEST_PUBDIR}/tl.gz"
@@ -218,6 +232,11 @@ run_case () {
 	corrupt-existing-f)
 		printf 'corrupt metadata\n' | gzip -c \
 			> "${TEST_PUBDIR}/f/${TEST_HASH}.gz"
+		;;
+	oversized-existing-f)
+		dd if=/dev/zero \
+			of="${TEST_PUBDIR}/f/${TEST_HASH}.gz" \
+			bs=1 count=1 seek=67108864 2>/dev/null
 		;;
 	corrupt-existing-t)
 		printf 'corrupt tag\n' > "${TEST_PUBDIR}/t/${TEST_TAG_HASH}"
@@ -241,13 +260,18 @@ run_case () {
 		printf 'corrupt snapshot\n' \
 			> "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz"
 		;;
-	corrupt-existing-tp|corrupt-existing-tp-source)
+	corrupt-existing-tp|corrupt-existing-tp-source|corrupt-existing-tp-bomb)
 		cp "${TEST_ORIGIN}/f/${TEST_META_OLD_HASH}.gz" \
 			"${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz"
 		cp "${TEST_ORIGIN}/f/${TEST_META_NEW_HASH}.gz" \
 			"${TEST_PUBDIR}/f/${TEST_META_NEW_HASH}.gz"
-		printf 'corrupt metadata patch\n' | gzip -c \
-			> "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
+		if [ "${TEST_MODE}" = corrupt-existing-tp-bomb ]; then
+			dd if=/dev/zero bs=1048576 count=65 2>/dev/null | gzip -c \
+				> "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
+		else
+			printf 'corrupt metadata patch\n' | gzip -c \
+				> "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
+		fi
 		if [ "${TEST_MODE}" = corrupt-existing-tp-source ]; then
 			printf 'corrupt metadata source\n' | gzip -c \
 				> "${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz"
@@ -346,6 +370,7 @@ run_case () {
 		fi
 	if [ "${TEST_MODE}" = corrupt-existing-tp ] ||
 	    [ "${TEST_MODE}" = corrupt-existing-tp-source ] ||
+	    [ "${TEST_MODE}" = corrupt-existing-tp-bomb ] ||
 	    [ "${TEST_MODE}" = symlink-existing ]; then
 			[ -f "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz" ]
 			gunzip -t "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
@@ -403,6 +428,7 @@ run_case "${TEST_SCRIPT}" bad-hash failure
 run_case "${TEST_SCRIPT}" bad-expanded-f failure
 run_case "${TEST_SCRIPT}" bad-tag failure
 run_case "${TEST_SCRIPT}" bad-bp failure
+run_case "${TEST_SCRIPT}" bad-bp-target-size failure
 run_case "${TEST_SCRIPT}" bad-snapshot failure
 run_case "${TEST_SCRIPT}" bad-snapshot-link failure
 run_case "${TEST_SCRIPT}" bad-snapshot-duplicate failure
@@ -411,12 +437,14 @@ run_case "${TEST_SCRIPT}" unchanged success
 run_case "${TEST_SCRIPT}" unchanged-skew success
 run_case "${TEST_SCRIPT}" unchanged-extra success
 run_case "${TEST_SCRIPT}" corrupt-existing-f success
+run_case "${TEST_SCRIPT}" oversized-existing-f success
 run_case "${TEST_SCRIPT}" corrupt-existing-t success
 run_case "${TEST_SCRIPT}" corrupt-existing-bp success
 run_case "${TEST_SCRIPT}" corrupt-existing-s success
 run_case "${TEST_SCRIPT}" changed-corrupt-existing success
 run_case "${TEST_SCRIPT}" corrupt-existing-tp success
 run_case "${TEST_SCRIPT}" corrupt-existing-tp-source success
+run_case "${TEST_SCRIPT}" corrupt-existing-tp-bomb success
 run_case "${TEST_SCRIPT}" quarantine-extra success
 run_case "${TEST_SCRIPT}" symlink-existing success
 run_case "${TEST_SCRIPT}" failed-repair-preserves-existing failure

--- a/tests/f2-regression.sh
+++ b/tests/f2-regression.sh
@@ -42,9 +42,15 @@ cat > "${TEST_BINDIR}/lam" <<'EOF'
 #!/bin/sh
 [ "$1" = "-s" ]
 TEST_PREFIX=$2
+TEST_INPUT=$3
+shift 3
+TEST_SUFFIX=
+if [ "${1:-}" = "-s" ]; then
+	TEST_SUFFIX=$2
+fi
 while read TEST_LINE; do
-	printf '%s%s\n' "${TEST_PREFIX}" "${TEST_LINE}"
-done < "$3"
+	printf '%s%s%s\n' "${TEST_PREFIX}" "${TEST_LINE}" "${TEST_SUFFIX}"
+done < "${TEST_INPUT}"
 EOF
 
 cat > "${TEST_BINDIR}/sha256" <<'EOF'
@@ -72,9 +78,18 @@ fi
 exec /usr/bin/mktemp "$@"
 EOF
 
+cat > "${TEST_BINDIR}/bspatch" <<'EOF'
+#!/bin/sh
+TEST_EXPECTED=`sed -n '1p' "$3"`
+TEST_ACTUAL=`sha256sum "$1" | awk '{ print $1 }'`
+[ "${TEST_ACTUAL}" = "${TEST_EXPECTED}" ] || exit 1
+sed '1d' "$3" > "$2"
+EOF
+
 chmod +x "${TEST_BINDIR}/phttpget" "${TEST_BINDIR}/fetch" \
 	"${TEST_BINDIR}/lam" "${TEST_BINDIR}/sha256" \
-	"${TEST_BINDIR}/xargs" "${TEST_BINDIR}/mktemp"
+	"${TEST_BINDIR}/xargs" "${TEST_BINDIR}/mktemp" \
+	"${TEST_BINDIR}/bspatch"
 
 run_case () {
 	TEST_SCRIPT=$1
@@ -91,13 +106,29 @@ run_case () {
 		"${TEST_PUBDIR}/t" "${TEST_PUBDIR}/tp" \
 		"${TEST_CASE}/work"
 
-	TEST_HASH=`printf 'valid metadata\n' | sha256sum | awk '{ print $1 }'`
+	TEST_FILE_HASH=`printf 'valid file\n' | sha256sum | awk '{ print $1 }'`
+	printf 'oldfile|%s\n' "${TEST_FILE_HASH}" > "${TEST_CASE}/INDEX.old"
+	printf 'file|%s\n' "${TEST_FILE_HASH}" > "${TEST_CASE}/INDEX.new"
+	TEST_OLD_HASH=`sha256sum "${TEST_CASE}/INDEX.old" | awk '{ print $1 }'`
+	TEST_HASH=`sha256sum "${TEST_CASE}/INDEX.new" | awk '{ print $1 }'`
+	printf 'A|%s\n' "${TEST_OLD_HASH}" > "${TEST_CASE}/metadata.old"
+	printf 'A|%s\nB|%s\n' "${TEST_OLD_HASH}" "${TEST_HASH}" \
+		> "${TEST_CASE}/metadata.new"
+	TEST_META_OLD_HASH=`sha256sum "${TEST_CASE}/metadata.old" | awk '{ print $1 }'`
+	TEST_META_NEW_HASH=`sha256sum "${TEST_CASE}/metadata.new" | awk '{ print $1 }'`
+	printf 'INDEX|%s\n' "${TEST_HASH}" > "${TEST_CASE}/snapshot.tag"
+	TEST_SNAPSHOT_HASH=`sha256sum "${TEST_CASE}/snapshot.tag" | awk '{ print $1 }'`
 	TEST_TAG_HASH=`printf 'valid tag\n' | sha256sum | awk '{ print $1 }'`
-	TEST_SENTINEL=0000000000000000000000000000000000000000000000000000000000000000
-	printf 'INDEX|200000|%s|200001|%s\n' "${TEST_HASH}" "${TEST_HASH}" \
+	TEST_SENTINEL=`printf 'retained object\n' | sha256sum | awk '{ print $1 }'`
+	TEST_BAD_HASH=0000000000000000000000000000000000000000000000000000000000000000
+	printf 'INDEX|200000|%s\nINDEX|200001|%s\n' \
+		"${TEST_OLD_HASH}" "${TEST_HASH}" \
 		> "${TEST_CASE}/bl"
-	: > "${TEST_CASE}/tl"
-	printf 's/%s.tgz\nt/%s\n' "${TEST_HASH}" "${TEST_TAG_HASH}" \
+	printf 'DESCRIBE|199999|%s\nDESCRIBE|200001|%s\n' \
+		"${TEST_META_OLD_HASH}" "${TEST_META_NEW_HASH}" \
+		> "${TEST_CASE}/tl"
+	printf 's/%s.tgz\nt/%s\nt/%s\n' "${TEST_SNAPSHOT_HASH}" \
+		"${TEST_SNAPSHOT_HASH}" "${TEST_TAG_HASH}" \
 		> "${TEST_CASE}/el"
 	gzip -c "${TEST_CASE}/bl" > "${TEST_ORIGIN}/bl.gz"
 	gzip -c "${TEST_CASE}/tl" > "${TEST_ORIGIN}/tl.gz"
@@ -105,8 +136,19 @@ run_case () {
 	printf 'public key\n' > "${TEST_ORIGIN}/pub.ssl"
 	printf 'snapshot signature\n' > "${TEST_ORIGIN}/snapshot.ssl"
 	printf 'new signature\n' > "${TEST_ORIGIN}/latest.ssl"
-	printf 'binary patch\n' > "${TEST_ORIGIN}/bp/${TEST_HASH}-${TEST_HASH}"
-	printf 'snapshot\n' > "${TEST_ORIGIN}/s/${TEST_HASH}.tgz"
+	printf '%s\n' "${TEST_OLD_HASH}" \
+		> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+	sed -n '1,$p' "${TEST_CASE}/INDEX.new" \
+		>> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+	mkdir -p "${TEST_CASE}/snapshot/snap"
+	gzip -c "${TEST_CASE}/INDEX.new" \
+		> "${TEST_CASE}/snapshot/snap/${TEST_HASH}.gz"
+	printf 'valid file\n' | gzip -c \
+		> "${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
+	( cd "${TEST_CASE}/snapshot" && tar -czf \
+		"${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" snap )
+	cp "${TEST_CASE}/snapshot.tag" \
+		"${TEST_ORIGIN}/t/${TEST_SNAPSHOT_HASH}"
 	case ${TEST_MODE} in
 	bad-tag) printf 'invalid tag\n' > "${TEST_ORIGIN}/t/${TEST_TAG_HASH}" ;;
 	*) printf 'valid tag\n' > "${TEST_ORIGIN}/t/${TEST_TAG_HASH}" ;;
@@ -114,25 +156,56 @@ run_case () {
 	printf 'public key\n' > "${TEST_PUBDIR}/pub.ssl"
 	: > "${TEST_PUBDIR}/indextimes"
 
-	case ${TEST_MODE} in
-	bad-hash)
+	gzip -c "${TEST_CASE}/INDEX.old" \
+		> "${TEST_ORIGIN}/f/${TEST_OLD_HASH}.gz"
+	gzip -c "${TEST_CASE}/INDEX.new" \
+		> "${TEST_ORIGIN}/f/${TEST_HASH}.gz"
+	gzip -c "${TEST_CASE}/metadata.old" \
+		> "${TEST_ORIGIN}/f/${TEST_META_OLD_HASH}.gz"
+	gzip -c "${TEST_CASE}/metadata.new" \
+		> "${TEST_ORIGIN}/f/${TEST_META_NEW_HASH}.gz"
+	if [ "${TEST_MODE}" = bad-hash ]; then
 		printf 'invalid metadata\n' | gzip -c \
 			> "${TEST_ORIGIN}/f/${TEST_HASH}.gz"
-		;;
-	*)
-		printf 'valid metadata\n' | gzip -c \
+	fi
+	if [ "${TEST_MODE}" = bad-expanded-f ]; then
+		dd if=/dev/zero bs=1048576 count=65 2>/dev/null | gzip -c \
 			> "${TEST_ORIGIN}/f/${TEST_HASH}.gz"
-		;;
-	esac
+	fi
+	if [ "${TEST_MODE}" = bad-bp ]; then
+		printf 'invalid binary patch\n' \
+			> "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+	fi
+	if [ "${TEST_MODE}" = bad-snapshot ]; then
+		printf 'corrupt archived file\n' | gzip -c \
+			> "${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
+		( cd "${TEST_CASE}/snapshot" && tar -czf \
+			"${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" snap )
+	fi
+	if [ "${TEST_MODE}" = bad-snapshot-link ]; then
+		rm "${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
+		ln -s /tmp/portsnap-snapshot-escape \
+			"${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
+		( cd "${TEST_CASE}/snapshot" && tar -czf \
+			"${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" snap )
+	fi
+	if [ "${TEST_MODE}" = bad-snapshot-duplicate ]; then
+		( cd "${TEST_CASE}/snapshot" &&
+		  tar -cf "${TEST_CASE}/snapshot.tar" snap &&
+		  tar -rf "${TEST_CASE}/snapshot.tar" \
+		    "snap/${TEST_FILE_HASH}.gz" )
+		gzip -c "${TEST_CASE}/snapshot.tar" \
+			> "${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz"
+	fi
 
 	case ${TEST_MODE} in
-	unchanged|unchanged-skew|corrupt-existing-f|corrupt-existing-t|symlink-existing)
+	unchanged|unchanged-skew|unchanged-extra|corrupt-existing-f|corrupt-existing-t|corrupt-existing-bp|corrupt-existing-s|corrupt-existing-tp|corrupt-existing-tp-source|failed-repair-preserves-existing|directory-existing|symlink-existing)
 		printf 'new signature\n' > "${TEST_PUBDIR}/latest.ssl"
 		cp "${TEST_ORIGIN}/bl.gz" "${TEST_PUBDIR}/bl.gz"
 		cp "${TEST_ORIGIN}/tl.gz" "${TEST_PUBDIR}/tl.gz"
 		cp "${TEST_ORIGIN}/el.gz" "${TEST_PUBDIR}/el.gz"
 		cp "${TEST_PUBDIR}/bl.gz" "${TEST_CASE}/published-bl.gz"
-		printf 'retained object\n' \
+		printf 'retained object\n' | gzip -c \
 			> "${TEST_PUBDIR}/f/${TEST_SENTINEL}.gz"
 		;;
 	*) printf 'old signature\n' > "${TEST_PUBDIR}/latest.ssl" ;;
@@ -149,22 +222,87 @@ run_case () {
 	corrupt-existing-t)
 		printf 'corrupt tag\n' > "${TEST_PUBDIR}/t/${TEST_TAG_HASH}"
 		;;
+	corrupt-existing-bp)
+		printf 'corrupt binary patch\n' \
+			> "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+		;;
+	corrupt-existing-s)
+		printf 'corrupt archived file\n' | gzip -c \
+			> "${TEST_CASE}/snapshot/snap/${TEST_FILE_HASH}.gz"
+		( cd "${TEST_CASE}/snapshot" && tar -czf \
+			"${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz" snap )
+		;;
+	changed-corrupt-existing)
+		printf 'corrupt metadata\n' | gzip -c \
+			> "${TEST_PUBDIR}/f/${TEST_HASH}.gz"
+		printf 'corrupt tag\n' > "${TEST_PUBDIR}/t/${TEST_TAG_HASH}"
+		printf 'corrupt binary patch\n' \
+			> "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+		printf 'corrupt snapshot\n' \
+			> "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz"
+		;;
+	corrupt-existing-tp|corrupt-existing-tp-source)
+		cp "${TEST_ORIGIN}/f/${TEST_META_OLD_HASH}.gz" \
+			"${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz"
+		cp "${TEST_ORIGIN}/f/${TEST_META_NEW_HASH}.gz" \
+			"${TEST_PUBDIR}/f/${TEST_META_NEW_HASH}.gz"
+		printf 'corrupt metadata patch\n' | gzip -c \
+			> "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
+		if [ "${TEST_MODE}" = corrupt-existing-tp-source ]; then
+			printf 'corrupt metadata source\n' | gzip -c \
+				> "${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz"
+		fi
+		;;
+	failed-repair-preserves-existing)
+		printf 'corrupt metadata to preserve\n' | gzip -c \
+			> "${TEST_PUBDIR}/f/${TEST_HASH}.gz"
+		;;
+	directory-existing)
+		mkdir "${TEST_PUBDIR}/f/${TEST_HASH}.gz"
+		;;
+	quarantine-extra|unchanged-extra)
+		printf 'corrupt extra file\n' | gzip -c \
+			> "${TEST_PUBDIR}/f/${TEST_BAD_HASH}.gz"
+		printf 'corrupt extra tag\n' \
+			> "${TEST_PUBDIR}/t/${TEST_BAD_HASH}"
+		printf 'corrupt extra patch\n' \
+			> "${TEST_PUBDIR}/bp/${TEST_BAD_HASH}-${TEST_BAD_HASH}"
+		printf 'corrupt extra snapshot\n' \
+			> "${TEST_PUBDIR}/s/${TEST_BAD_HASH}.tgz"
+		printf 'corrupt extra metadata patch\n' | gzip -c \
+			> "${TEST_PUBDIR}/tp/${TEST_BAD_HASH}-${TEST_BAD_HASH}.gz"
+		;;
 	symlink-existing)
+		cp "${TEST_ORIGIN}/f/${TEST_META_OLD_HASH}.gz" \
+			"${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz"
+		cp "${TEST_ORIGIN}/f/${TEST_META_NEW_HASH}.gz" \
+			"${TEST_PUBDIR}/f/${TEST_META_NEW_HASH}.gz"
+		printf 'corrupt metadata patch\n' | gzip -c \
+			> "${TEST_CASE}/tp-link.gz"
 		ln -s "${TEST_ORIGIN}/f/${TEST_HASH}.gz" \
 			"${TEST_PUBDIR}/f/${TEST_HASH}.gz"
 		ln -s "${TEST_ORIGIN}/t/${TEST_TAG_HASH}" \
 			"${TEST_PUBDIR}/t/${TEST_TAG_HASH}"
+		ln -s "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}" \
+			"${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+		ln -s "${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" \
+			"${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz"
+		ln -s "${TEST_CASE}/tp-link.gz" \
+			"${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
 		;;
 	esac
 
-	sed 's#/usr/libexec/phttpget#phttpget#' "${TEST_SCRIPT}" \
+	sed -e 's#/usr/libexec/phttpget#phttpget#' \
+	    -e 's#/usr/bin/bspatch#bspatch#' "${TEST_SCRIPT}" \
 		> "${TEST_CASE}/mirror.sh"
 
 	TEST_FAIL_OBJECT=
 	TEST_OMIT_OBJECT=
 	case ${TEST_MODE} in
 	failure) TEST_FAIL_OBJECT=f/${TEST_HASH}.gz ;;
-	missing) TEST_OMIT_OBJECT=f/${TEST_HASH}.gz ;;
+	missing|failed-repair-preserves-existing)
+		TEST_OMIT_OBJECT=f/${TEST_HASH}.gz
+		;;
 	esac
 
 	TEST_STATUS=0
@@ -187,26 +325,73 @@ run_case () {
 			return 1
 		fi
 		[ -f "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
-		[ -f "${TEST_PUBDIR}/bp/${TEST_HASH}-${TEST_HASH}" ]
-		[ -f "${TEST_PUBDIR}/s/${TEST_HASH}.tgz" ]
+		[ -f "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}" ]
+		[ -f "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz" ]
 		[ -f "${TEST_PUBDIR}/t/${TEST_TAG_HASH}" ]
+		[ -f "${TEST_PUBDIR}/t/${TEST_SNAPSHOT_HASH}" ]
 		[ `gunzip -c "${TEST_PUBDIR}/f/${TEST_HASH}.gz" | sha256sum | awk '{ print $1 }'` = "${TEST_HASH}" ]
 		[ `sha256sum "${TEST_PUBDIR}/t/${TEST_TAG_HASH}" | awk '{ print $1 }'` = "${TEST_TAG_HASH}" ]
 		[ ! -L "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
 		[ ! -L "${TEST_PUBDIR}/t/${TEST_TAG_HASH}" ]
+		[ ! -L "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}" ]
+		[ ! -L "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz" ]
+		cmp -s "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}" \
+			"${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
+		cmp -s "${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" \
+			"${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz"
 		cmp -s "${TEST_ORIGIN}/latest.ssl" "${TEST_PUBDIR}/latest.ssl"
 		if [ -f "${TEST_CASE}/published-bl.gz" ]; then
 			cmp -s "${TEST_CASE}/published-bl.gz" "${TEST_PUBDIR}/bl.gz"
-			[ -f "${TEST_PUBDIR}/f/${TEST_SENTINEL}.gz" ]
+			[ ! -f "${TEST_PUBDIR}/f/${TEST_SENTINEL}.gz" ]
+		fi
+	if [ "${TEST_MODE}" = corrupt-existing-tp ] ||
+	    [ "${TEST_MODE}" = corrupt-existing-tp-source ] ||
+	    [ "${TEST_MODE}" = symlink-existing ]; then
+			[ -f "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz" ]
+			gunzip -t "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz"
+			gunzip -c "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz" \
+				> "${TEST_CASE}/tp.diff"
+			gunzip -c "${TEST_PUBDIR}/f/${TEST_META_OLD_HASH}.gz" \
+				> "${TEST_CASE}/tp.old"
+			cut -c 2- "${TEST_CASE}/tp.diff" |
+				join -t '|' -v 2 - "${TEST_CASE}/tp.old" \
+				> "${TEST_CASE}/tp.tmp"
+			awk '/^\+/ { print substr($0, 2) }' "${TEST_CASE}/tp.diff" |
+				sort -k 1,1 -t '|' -m - "${TEST_CASE}/tp.tmp" \
+				> "${TEST_CASE}/tp.new"
+			[ `sha256sum "${TEST_CASE}/tp.new" | awk '{ print $1 }'` = \
+				"${TEST_META_NEW_HASH}" ]
+			[ ! -L "${TEST_PUBDIR}/tp/${TEST_META_OLD_HASH}-${TEST_META_NEW_HASH}.gz" ]
+		fi
+		if [ "${TEST_MODE}" = quarantine-extra ] ||
+		    [ "${TEST_MODE}" = unchanged-extra ]; then
+			[ ! -e "${TEST_PUBDIR}/f/${TEST_BAD_HASH}.gz" ]
+			[ ! -e "${TEST_PUBDIR}/t/${TEST_BAD_HASH}" ]
+			[ ! -e "${TEST_PUBDIR}/bp/${TEST_BAD_HASH}-${TEST_BAD_HASH}" ]
+			[ ! -e "${TEST_PUBDIR}/s/${TEST_BAD_HASH}.tgz" ]
+			[ ! -e "${TEST_PUBDIR}/tp/${TEST_BAD_HASH}-${TEST_BAD_HASH}.gz" ]
 		fi
 		;;
 	failure)
 		[ ${TEST_STATUS} -ne 0 ]
-		[ ! -f "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
-		[ ! -f "${TEST_PUBDIR}/bp/${TEST_HASH}-${TEST_HASH}" ]
-		[ ! -f "${TEST_PUBDIR}/s/${TEST_HASH}.tgz" ]
+		if [ "${TEST_MODE}" = failed-repair-preserves-existing ]; then
+			[ -f "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
+			[ "`gunzip -c "${TEST_PUBDIR}/f/${TEST_HASH}.gz"`" = \
+				"corrupt metadata to preserve" ]
+		elif [ "${TEST_MODE}" = directory-existing ]; then
+			[ -d "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
+		else
+			[ ! -f "${TEST_PUBDIR}/f/${TEST_HASH}.gz" ]
+		fi
+		[ ! -f "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}" ]
+		[ ! -f "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz" ]
 		[ ! -f "${TEST_PUBDIR}/t/${TEST_TAG_HASH}" ]
-		grep -q '^old signature$' "${TEST_PUBDIR}/latest.ssl"
+		if [ "${TEST_MODE}" = failed-repair-preserves-existing ] ||
+		    [ "${TEST_MODE}" = directory-existing ]; then
+			grep -q '^new signature$' "${TEST_PUBDIR}/latest.ssl"
+		else
+			grep -q '^old signature$' "${TEST_PUBDIR}/latest.ssl"
+		fi
 		;;
 	esac
 }
@@ -215,12 +400,26 @@ TEST_SCRIPT=pmirror.sh
 run_case "${TEST_SCRIPT}" failure failure
 run_case "${TEST_SCRIPT}" missing failure
 run_case "${TEST_SCRIPT}" bad-hash failure
+run_case "${TEST_SCRIPT}" bad-expanded-f failure
 run_case "${TEST_SCRIPT}" bad-tag failure
+run_case "${TEST_SCRIPT}" bad-bp failure
+run_case "${TEST_SCRIPT}" bad-snapshot failure
+run_case "${TEST_SCRIPT}" bad-snapshot-link failure
+run_case "${TEST_SCRIPT}" bad-snapshot-duplicate failure
 run_case "${TEST_SCRIPT}" success success
 run_case "${TEST_SCRIPT}" unchanged success
 run_case "${TEST_SCRIPT}" unchanged-skew success
+run_case "${TEST_SCRIPT}" unchanged-extra success
 run_case "${TEST_SCRIPT}" corrupt-existing-f success
 run_case "${TEST_SCRIPT}" corrupt-existing-t success
+run_case "${TEST_SCRIPT}" corrupt-existing-bp success
+run_case "${TEST_SCRIPT}" corrupt-existing-s success
+run_case "${TEST_SCRIPT}" changed-corrupt-existing success
+run_case "${TEST_SCRIPT}" corrupt-existing-tp success
+run_case "${TEST_SCRIPT}" corrupt-existing-tp-source success
+run_case "${TEST_SCRIPT}" quarantine-extra success
 run_case "${TEST_SCRIPT}" symlink-existing success
+run_case "${TEST_SCRIPT}" failed-repair-preserves-existing failure
+run_case "${TEST_SCRIPT}" directory-existing failure
 
-echo "F2 regression tests passed"
+echo "F2/F5 regression tests passed"


### PR DESCRIPTION
Closes the F5 mirror-integrity finding by validating every retained object class with the MidnightBSD portsnap protocol before publication. Required repairs are downloaded into private same-filesystem staging and atomically installed only after validation; unchanged generations now repair and prune as well. Snapshot validation rejects unsafe archive members and bounds archive and inner-object expansion. Regression coverage includes corrupt existing f, t, bp, s, and tp objects, symlinks, changed and unchanged generations, failed-repair preservation, archive duplicates and links, oversized gzip content, and semantic metadata/binary patch checks.

Validation:
- sh -n pmirror.sh tests/f2-regression.sh
- sh tests/f2-regression.sh
- checkbashisms pmirror.sh tests/f2-regression.sh
- git diff --check

## Summary by Sourcery

Scrub and validate every retained portsnap object before atomically repairing, pruning, and publishing mirror contents.

New Features:
- Validate and repair all retained portsnap object classes, including files, tags, binary patches, metadata patches, and snapshots, before publication.
- Add bounded snapshot archive and object expansion checks that reject unsafe members, links, duplicates, malformed metadata, and oversized content.

Bug Fixes:
- Prevent corrupt, missing, symlinked, or invalid retained objects from being published or served, while preserving existing content when repairs fail.
- Ensure unchanged generations are scrubbed and pruned instead of bypassing integrity maintenance.
- Publish validated repairs atomically and fail closed when required objects cannot be repaired.

Enhancements:
- Retain valid binary-patch source objects and remove invalid or out-of-retention objects through private staging.
- Strengthen metadata patch generation and validation, including support for repairing invalid retained patches.

Documentation:
- Update requirements and operational documentation to describe portsnap-protocol validation, repair, pruning, staging, and archive safety behavior.

Tests:
- Expand regression coverage across corrupt retained object classes, unsafe snapshots, oversized content, symlinks, unchanged generations, failed repairs, and invalid object types.