### PR TITLE
Fix false corruption reports for large gzip objects

### DIFF
--- a/pmirror.sh
+++ b/pmirror.sh
@@ -92,26 +92,26 @@ METADATA_PATCH_MAX_SOURCE_BYTES=100000
 
 # Bounded gzip expansion which requires the producer to reach a clean EOF.  The
 # FIFO lets POSIX sh preserve both command statuses without non-portable
-# pipefail.  COUNT is one MiB block beyond MAX_BYTES so oversize streams fail.
+# pipefail.  head counts bytes rather than short FIFO reads, and one byte beyond
+# MAX_BYTES lets the final size check reject oversized streams.
 expand_gzip_file () {
 	EXPAND_GZIP_SOURCE=$1
 	EXPAND_GZIP_OUTPUT=$2
 	EXPAND_GZIP_MAX_BYTES=$3
-	EXPAND_GZIP_COUNT=$4
+	EXPAND_GZIP_LIMIT=`expr ${EXPAND_GZIP_MAX_BYTES} + 1`
 	EXPAND_GZIP_FIFO=${WRKDIR}/gzip.verify.fifo
 
 	rm -f "${EXPAND_GZIP_FIFO}" "${EXPAND_GZIP_OUTPUT}"
 	mkfifo "${EXPAND_GZIP_FIFO}"
 	gunzip -c "${EXPAND_GZIP_SOURCE}" > "${EXPAND_GZIP_FIFO}" 2>/dev/null &
 	EXPAND_GZIP_PID=$!
-	EXPAND_GZIP_DD_STATUS=0
-	dd if="${EXPAND_GZIP_FIFO}" of="${EXPAND_GZIP_OUTPUT}" \
-	    bs=1048576 count=${EXPAND_GZIP_COUNT} 2>/dev/null ||
-	    EXPAND_GZIP_DD_STATUS=$?
+	EXPAND_GZIP_HEAD_STATUS=0
+	head -c ${EXPAND_GZIP_LIMIT} < "${EXPAND_GZIP_FIFO}" \
+	    > "${EXPAND_GZIP_OUTPUT}" || EXPAND_GZIP_HEAD_STATUS=$?
 	EXPAND_GZIP_STATUS=0
 	wait ${EXPAND_GZIP_PID} || EXPAND_GZIP_STATUS=$?
 	rm -f "${EXPAND_GZIP_FIFO}"
-	if [ ${EXPAND_GZIP_DD_STATUS} -ne 0 ] ||
+	if [ ${EXPAND_GZIP_HEAD_STATUS} -ne 0 ] ||
 	    [ ${EXPAND_GZIP_STATUS} -ne 0 ] ||
 	    [ `wc -c < "${EXPAND_GZIP_OUTPUT}"` -gt \
 	    ${EXPAND_GZIP_MAX_BYTES} ]; then
@@ -125,7 +125,7 @@ hash_gzip_file () {
 	HASH_GZIP_OUTPUT=$2
 
 	expand_gzip_file "${HASH_GZIP_SOURCE}" "${HASH_GZIP_OUTPUT}" \
-	    ${OBJECT_MAX_EXPANDED_BYTES} 65 || return 1
+	    ${OBJECT_MAX_EXPANDED_BYTES} || return 1
 	sha256 < "${HASH_GZIP_OUTPUT}"
 }
 
@@ -377,7 +377,7 @@ validate_binary_patches () {
 		    [ ${VALIDATE_TARGET_SIZE} -ge 0 ] &&
 		    [ ${VALIDATE_TARGET_SIZE} -le ${OBJECT_MAX_EXPANDED_BYTES} ] &&
 		    expand_gzip_file "${VALIDATE_SOURCE}" "${VALIDATE_OLD}" \
-		    ${OBJECT_MAX_EXPANDED_BYTES} 65 &&
+		    ${OBJECT_MAX_EXPANDED_BYTES} &&
 		    ${BSPATCH} "${VALIDATE_OLD}" "${VALIDATE_NEW}" \
 		    "${VALIDATE_PATH}" >/dev/null 2>&1 &&
 		    [ -f "${VALIDATE_NEW}" ] && [ ! -L "${VALIDATE_NEW}" ] &&
@@ -422,9 +422,9 @@ validate_metadata_patches () {
 		if [ -f "${VALIDATE_PATH}" ] && [ ! -L "${VALIDATE_PATH}" ] &&
 		    [ -n "${VALIDATE_SOURCE}" ] &&
 		    expand_gzip_file "${VALIDATE_PATH}" "${VALIDATE_DIFF}" \
-		    ${OBJECT_MAX_EXPANDED_BYTES} 65 &&
+		    ${OBJECT_MAX_EXPANDED_BYTES} &&
 		    expand_gzip_file "${VALIDATE_SOURCE}" "${VALIDATE_OLD}" \
-		    ${OBJECT_MAX_EXPANDED_BYTES} 65; then
+		    ${OBJECT_MAX_EXPANDED_BYTES}; then
 			cut -c 2- "${VALIDATE_DIFF}" |
 			    join -t '|' -v 2 - "${VALIDATE_OLD}" > "${VALIDATE_TMP}"
 			awk '/^\+/ { print substr($0, 2) }' "${VALIDATE_DIFF}" |
@@ -467,7 +467,7 @@ validate_snapshots () {
 		    ${SNAPSHOT_MAX_ARCHIVE_BYTES} ] &&
 		    expand_gzip_file "${VALIDATE_PATH}" \
 		    "${VALIDATE_DIR}/snapshot.tar" \
-		    ${SNAPSHOT_MAX_EXPANDED_BYTES} 1025 &&
+		    ${SNAPSHOT_MAX_EXPANDED_BYTES} &&
 		    [ -n "${VALIDATE_TAG}" ] &&
 		    ! grep -qvE '^[0-9A-Z.]+\|[0-9a-f]{64}$' "${VALIDATE_TAG}" &&
 		    [ `grep '^INDEX|' "${VALIDATE_TAG}" | wc -l` -eq 1 ] &&

--- a/tests/f2-regression.sh
+++ b/tests/f2-regression.sh
@@ -123,12 +123,21 @@ run_case () {
 	TEST_TAG_HASH=`printf 'valid tag\n' | sha256sum | awk '{ print $1 }'`
 	TEST_SENTINEL=`printf 'retained object\n' | sha256sum | awk '{ print $1 }'`
 	TEST_BAD_HASH=0000000000000000000000000000000000000000000000000000000000000000
+	TEST_LARGE_HASH=
 	printf 'INDEX|200000|%s\nINDEX|200001|%s\n' \
 		"${TEST_OLD_HASH}" "${TEST_HASH}" \
 		> "${TEST_CASE}/bl"
 	printf 'DESCRIBE|199999|%s\nDESCRIBE|200001|%s\n' \
 		"${TEST_META_OLD_HASH}" "${TEST_META_NEW_HASH}" \
 		> "${TEST_CASE}/tl"
+	if [ "${TEST_MODE}" = large-valid-f ]; then
+		dd if=/dev/zero of="${TEST_CASE}/large.valid" \
+			bs=1048576 count=6 2>/dev/null
+		TEST_LARGE_HASH=`sha256sum "${TEST_CASE}/large.valid" | \
+			awk '{ print $1 }'`
+		printf 'LARGE|200001|%s\n' "${TEST_LARGE_HASH}" \
+			>> "${TEST_CASE}/tl"
+	fi
 	printf 's/%s.tgz\nt/%s\nt/%s\n' "${TEST_SNAPSHOT_HASH}" \
 		"${TEST_SNAPSHOT_HASH}" "${TEST_TAG_HASH}" \
 		> "${TEST_CASE}/el"
@@ -171,6 +180,10 @@ run_case () {
 		> "${TEST_ORIGIN}/f/${TEST_META_OLD_HASH}.gz"
 	gzip -c "${TEST_CASE}/metadata.new" \
 		> "${TEST_ORIGIN}/f/${TEST_META_NEW_HASH}.gz"
+	if [ -n "${TEST_LARGE_HASH}" ]; then
+		gzip -c "${TEST_CASE}/large.valid" \
+			> "${TEST_ORIGIN}/f/${TEST_LARGE_HASH}.gz"
+	fi
 	if [ "${TEST_MODE}" = bad-hash ]; then
 		printf 'invalid metadata\n' | gzip -c \
 			> "${TEST_ORIGIN}/f/${TEST_HASH}.gz"
@@ -359,6 +372,11 @@ run_case () {
 		[ ! -L "${TEST_PUBDIR}/t/${TEST_TAG_HASH}" ]
 		[ ! -L "${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}" ]
 		[ ! -L "${TEST_PUBDIR}/s/${TEST_SNAPSHOT_HASH}.tgz" ]
+		if [ -n "${TEST_LARGE_HASH}" ]; then
+			[ -f "${TEST_PUBDIR}/f/${TEST_LARGE_HASH}.gz" ]
+			[ `gunzip -c "${TEST_PUBDIR}/f/${TEST_LARGE_HASH}.gz" | \
+			    sha256sum | awk '{ print $1 }'` = "${TEST_LARGE_HASH}" ]
+		fi
 		cmp -s "${TEST_ORIGIN}/bp/${TEST_OLD_HASH}-${TEST_HASH}" \
 			"${TEST_PUBDIR}/bp/${TEST_OLD_HASH}-${TEST_HASH}"
 		cmp -s "${TEST_ORIGIN}/s/${TEST_SNAPSHOT_HASH}.tgz" \
@@ -433,6 +451,7 @@ run_case "${TEST_SCRIPT}" bad-snapshot failure
 run_case "${TEST_SCRIPT}" bad-snapshot-link failure
 run_case "${TEST_SCRIPT}" bad-snapshot-duplicate failure
 run_case "${TEST_SCRIPT}" success success
+run_case "${TEST_SCRIPT}" large-valid-f success
 run_case "${TEST_SCRIPT}" unchanged success
 run_case "${TEST_SCRIPT}" unchanged-skew success
 run_case "${TEST_SCRIPT}" unchanged-extra success


### PR DESCRIPTION
## Summary

- bound gzip expansion by actual bytes instead of counting FIFO reads
- preserve clean-EOF and expanded-size validation
- add a regression case for a valid 6 MiB expanded object

## Cause

The previous helper used `dd bs=1048576 count=65` on a FIFO. Short pipe reads were counted as complete blocks, so valid objects could be truncated well below the 64 MiB limit and then rejected as corrupt.

## Verification

- `sh tests/f2-regression.sh`
- `sh -n pmirror.sh`
- `sh -n tests/f2-regression.sh`
- `git diff --check`

## Summary by Sourcery

Fix bounded gzip expansion so valid large objects are not truncated and incorrectly rejected as corrupt.

Bug Fixes:
- Prevent false corruption reports for valid large gzip objects by enforcing expansion limits based on actual output bytes.
- Preserve clean-EOF and expanded-size validation while correcting FIFO handling.

Tests:
- Add a regression test covering a valid 6 MiB expanded object.