### PR TITLE
Add manifest-aware portsnap cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ anywhere:
 
 ```sh
 sh tests/f2-regression.sh   # full suite; no network, no portsnap server needed
+sh tests/cleanup-regression.sh # primary-webroot cleanup suite; no network needed
 sh -n pmirror.sh            # syntax-only check
 ```
 
@@ -44,7 +45,9 @@ tp/`, an empty `latest.ssl`, and a `robots.txt` that disallows everything).
 ## Main files
 
 - **`pmirror.sh`** — the mirror implementation deployed by MidnightBSD.
+- **`portsnap-clean.sh`** — fail-closed, manifest-aware cleanup for a primary rsync web root.
 - **`tests/f2-regression.sh`** — the isolated regression suite for mirroring behavior.
+- **`tests/cleanup-regression.sh`** — isolated cleanup, quarantine, and manifest-validation tests.
 
 ## How a mirror run works
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,40 @@ Wrap the invocation in `lockf` so a slow run cannot overlap the next one:
 Each stage is announced with a timestamp on stdout, so cron mail is a usable log. A run
 against an unchanged generation says it is verifying mirror contents.
 
+## Cleaning a primary rsync web root
+
+Do not delete Portsnap objects based only on filesystem modification time. An immutable
+content-addressed object can remain referenced by a current manifest long after its
+original upload time.
+
+`portsnap-clean.sh` is intended for the primary webserver which receives a published
+tree via rsync. It reads only the local `bl.gz`, `tl.gz`, and `el.gz` manifests; it does
+not contact the private builder. By default it is a dry run:
+
+```sh
+/usr/local/portsnap-mirror/portsnap-clean.sh /home/portsnap/htmldocs/
+```
+
+Apply mode records when each object first becomes unreferenced. An object must remain
+unreferenced for 45 days before it is moved outside the web root into
+`/home/portsnap/.portsnap-clean/quarantine/`. Quarantine batches are retained for another
+30 days before deletion:
+
+```sh
+lockf -s -t 0 /home/portsnap/.portsnap-publish.lock \
+	/usr/local/portsnap-mirror/portsnap-clean.sh --apply /home/portsnap/htmldocs/
+```
+
+Use the same lock around the webserver-side rsync operation when possible. The script
+also compares stable copies of all manifests and control files before changing anything,
+rejects malformed or oversized manifests, ignores unexpected filenames, and never
+manages top-level control files. The grace period protects newly rsynced objects which
+arrive before their manifests and old objects referenced by cached manifests. Run it as
+the dedicated account which owns the web root; it refuses publication and state
+directories owned by another account or writable by a group or other users. The primary
+build's `bp/`, `f/`, `s/`, and `t/` directories are required; `tp/` is cleaned when
+present.
+
 ## Mirror script
 
 `pmirror.sh` is what mirror operators run.
@@ -68,6 +102,7 @@ against an unchanged generation says it is verifying mirror contents.
 
 ```sh
 sh tests/f2-regression.sh
+sh tests/cleanup-regression.sh
 ```
 
 The suite stubs out `phttpget` and `fetch` against a fake origin tree, so it needs no

--- a/portsnap-clean.sh
+++ b/portsnap-clean.sh
@@ -1,0 +1,503 @@
+#!/bin/sh -e
+
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -e
+umask 077
+
+CLEAN_APPLY=no
+CLEAN_GRACE_DAYS=45
+CLEAN_QUARANTINE_DAYS=30
+CLEAN_MANIFEST_MAX_COMPRESSED=67108864
+CLEAN_MANIFEST_MAX_EXPANDED=268435456
+CLEAN_MANIFEST_MAX_RECORDS=5000000
+CLEAN_MANIFEST_MAX_LINE=4096
+
+usage () {
+	echo "usage: $0 [--apply] [--grace-days days] [--quarantine-days days] pubdir" >&2
+	exit 1
+}
+
+valid_days () {
+	case $1 in
+	''|*[!0-9]*) return 1 ;;
+	esac
+	[ $1 -le 3650 ]
+}
+
+while [ $# -gt 0 ]; do
+	case $1 in
+	--apply)
+		CLEAN_APPLY=yes
+		shift
+		;;
+	--grace-days)
+		[ $# -ge 2 ] || usage
+		valid_days "$2" || usage
+		CLEAN_GRACE_DAYS=$2
+		shift 2
+		;;
+	--quarantine-days)
+		[ $# -ge 2 ] || usage
+		valid_days "$2" || usage
+		CLEAN_QUARANTINE_DAYS=$2
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	-*) usage ;;
+	*) break ;;
+	esac
+done
+
+[ $# -eq 1 ] || usage
+CLEAN_PUBDIR_INPUT=$1
+if [ -L "${CLEAN_PUBDIR_INPUT}" ] || ! [ -d "${CLEAN_PUBDIR_INPUT}" ]; then
+	echo "Refusing invalid or symlinked publication directory" >&2
+	exit 1
+fi
+CLEAN_PUBDIR=`cd "${CLEAN_PUBDIR_INPUT}" && pwd -P`
+case ${CLEAN_PUBDIR} in
+/|'')
+	echo "Refusing unsafe publication directory ${CLEAN_PUBDIR}" >&2
+	exit 1
+	;;
+esac
+
+file_owner () {
+	CLEAN_OWNER=`stat -f '%u' "$1" 2>/dev/null` || CLEAN_OWNER=
+	case ${CLEAN_OWNER} in
+	''|*[!0-9]*) stat -c '%u' "$1" 2>/dev/null ;;
+	*) echo "${CLEAN_OWNER}" ;;
+	esac
+}
+
+directory_is_private () {
+	[ -z "`find "$1" -prune \( -perm -020 -o -perm -002 \) -print`" ]
+}
+
+CLEAN_EUID=`id -u`
+CLEAN_PUBDIR_OWNER=`file_owner "${CLEAN_PUBDIR}"` || exit 1
+if [ "${CLEAN_PUBDIR_OWNER}" != "${CLEAN_EUID}" ]; then
+	echo "Run cleanup as the account which owns ${CLEAN_PUBDIR}" >&2
+	exit 1
+fi
+if ! directory_is_private "${CLEAN_PUBDIR}"; then
+	echo "Refusing group- or world-writable publication directory" >&2
+	exit 1
+fi
+
+CLEAN_SUBDIRS="bp f s t"
+if [ -e "${CLEAN_PUBDIR}/tp" ] || [ -L "${CLEAN_PUBDIR}/tp" ]; then
+	CLEAN_SUBDIRS="${CLEAN_SUBDIRS} tp"
+fi
+for CLEAN_SUBDIR in ${CLEAN_SUBDIRS}; do
+	if [ -L "${CLEAN_PUBDIR}/${CLEAN_SUBDIR}" ] ||
+	    ! [ -d "${CLEAN_PUBDIR}/${CLEAN_SUBDIR}" ]; then
+		echo "Missing or symlinked ${CLEAN_SUBDIR} directory" >&2
+		exit 1
+	fi
+	CLEAN_SUBDIR_OWNER=`file_owner "${CLEAN_PUBDIR}/${CLEAN_SUBDIR}"` || exit 1
+	if [ "${CLEAN_SUBDIR_OWNER}" != "${CLEAN_EUID}" ]; then
+		echo "Refusing ${CLEAN_SUBDIR} directory owned by another account" >&2
+		exit 1
+	fi
+	if ! directory_is_private "${CLEAN_PUBDIR}/${CLEAN_SUBDIR}"; then
+		echo "Refusing group- or world-writable ${CLEAN_SUBDIR} directory" >&2
+		exit 1
+	fi
+done
+
+CLEAN_PARENT=${CLEAN_PUBDIR%/*}
+[ -n "${CLEAN_PARENT}" ] || exit 1
+CLEAN_PARENT_OWNER=`file_owner "${CLEAN_PARENT}"` || exit 1
+if [ "${CLEAN_PARENT_OWNER}" != "${CLEAN_EUID}" ] ||
+    ! directory_is_private "${CLEAN_PARENT}"; then
+	echo "Refusing cleanup state parent not private to the web-root owner" >&2
+	exit 1
+fi
+CLEAN_STATE_DIR=${CLEAN_PARENT}/.portsnap-clean
+CLEAN_QUARANTINE_DIR=${CLEAN_STATE_DIR}/quarantine
+if [ -L "${CLEAN_STATE_DIR}" ]; then
+	echo "Refusing symlinked cleanup state directory" >&2
+	exit 1
+fi
+if [ -e "${CLEAN_STATE_DIR}" ]; then
+	CLEAN_STATE_OWNER=`file_owner "${CLEAN_STATE_DIR}"` || exit 1
+	if [ "${CLEAN_STATE_OWNER}" != "${CLEAN_EUID}" ]; then
+		echo "Refusing cleanup state owned by another account" >&2
+		exit 1
+	fi
+	if ! directory_is_private "${CLEAN_STATE_DIR}"; then
+		echo "Refusing group- or world-writable cleanup state" >&2
+		exit 1
+	fi
+fi
+if [ -L "${CLEAN_QUARANTINE_DIR}" ]; then
+	echo "Refusing symlinked quarantine directory" >&2
+	exit 1
+fi
+if [ -e "${CLEAN_QUARANTINE_DIR}" ]; then
+	CLEAN_QUARANTINE_OWNER=`file_owner "${CLEAN_QUARANTINE_DIR}"` || exit 1
+	if [ "${CLEAN_QUARANTINE_OWNER}" != "${CLEAN_EUID}" ] ||
+	    ! directory_is_private "${CLEAN_QUARANTINE_DIR}"; then
+		echo "Refusing quarantine directory not private to the web-root owner" >&2
+		exit 1
+	fi
+fi
+
+CLEAN_WRKDIR=`mktemp -d "${TMPDIR:-/tmp}/portsnap-clean.XXXXXX"` || exit 1
+CLEAN_LOCKDIR=
+cleanup () {
+	if [ -n "${CLEAN_LOCKDIR}" ] && [ -d "${CLEAN_LOCKDIR}" ]; then
+		rmdir "${CLEAN_LOCKDIR}" 2>/dev/null || true
+	fi
+	if [ -n "${CLEAN_WRKDIR}" ] && [ -d "${CLEAN_WRKDIR}" ]; then
+		rm -r "${CLEAN_WRKDIR}"
+	fi
+}
+trap cleanup 0
+trap 'exit 1' 1 2 15
+
+CLEAN_NOW=`date +%s`
+case ${CLEAN_NOW} in
+''|*[!0-9]*) exit 1 ;;
+esac
+CLEAN_GRACE_SECONDS=`awk -v days=${CLEAN_GRACE_DAYS} \
+    'BEGIN { printf "%.0f", days * 86400 }'`
+CLEAN_QUARANTINE_SECONDS=`awk -v days=${CLEAN_QUARANTINE_DAYS} \
+    'BEGIN { printf "%.0f", days * 86400 }'`
+CLEAN_CUTOFF=`expr ${CLEAN_NOW} - ${CLEAN_GRACE_SECONDS}`
+CLEAN_QUARANTINE_CUTOFF=`expr ${CLEAN_NOW} - ${CLEAN_QUARANTINE_SECONDS}`
+
+expand_manifest () {
+	CLEAN_EXPAND_SOURCE=$1
+	CLEAN_EXPAND_OUTPUT=$2
+	CLEAN_EXPAND_FIFO=${CLEAN_WRKDIR}/manifest.fifo
+	CLEAN_EXPAND_LIMIT=`expr ${CLEAN_MANIFEST_MAX_EXPANDED} + 1`
+
+	if [ `wc -c < "${CLEAN_EXPAND_SOURCE}"` -gt \
+	    ${CLEAN_MANIFEST_MAX_COMPRESSED} ]; then
+		return 1
+	fi
+	rm -f "${CLEAN_EXPAND_FIFO}" "${CLEAN_EXPAND_OUTPUT}"
+	mkfifo "${CLEAN_EXPAND_FIFO}"
+	gunzip -c "${CLEAN_EXPAND_SOURCE}" > "${CLEAN_EXPAND_FIFO}" 2>/dev/null &
+	CLEAN_EXPAND_PID=$!
+	CLEAN_HEAD_STATUS=0
+	head -c ${CLEAN_EXPAND_LIMIT} < "${CLEAN_EXPAND_FIFO}" \
+	    > "${CLEAN_EXPAND_OUTPUT}" || CLEAN_HEAD_STATUS=$?
+	CLEAN_GZIP_STATUS=0
+	wait ${CLEAN_EXPAND_PID} || CLEAN_GZIP_STATUS=$?
+	rm -f "${CLEAN_EXPAND_FIFO}"
+	if [ ${CLEAN_HEAD_STATUS} -ne 0 ] || [ ${CLEAN_GZIP_STATUS} -ne 0 ] ||
+	    [ `wc -c < "${CLEAN_EXPAND_OUTPUT}"` -gt \
+	    ${CLEAN_MANIFEST_MAX_EXPANDED} ]; then
+		return 1
+	fi
+}
+
+for CLEAN_CONTROL in bl.gz tl.gz el.gz latest.ssl pub.ssl snapshot.ssl; do
+	CLEAN_CONTROL_PATH=${CLEAN_PUBDIR}/${CLEAN_CONTROL}
+	if [ -L "${CLEAN_CONTROL_PATH}" ] || ! [ -f "${CLEAN_CONTROL_PATH}" ]; then
+		echo "Missing or symlinked ${CLEAN_CONTROL}" >&2
+		exit 1
+	fi
+	cp "${CLEAN_CONTROL_PATH}" "${CLEAN_WRKDIR}/${CLEAN_CONTROL}"
+done
+
+for CLEAN_MANIFEST in bl tl el; do
+	if ! expand_manifest "${CLEAN_WRKDIR}/${CLEAN_MANIFEST}.gz" \
+	    "${CLEAN_WRKDIR}/${CLEAN_MANIFEST}"; then
+		echo "Invalid or oversized ${CLEAN_MANIFEST}.gz" >&2
+		exit 1
+	fi
+done
+
+if ! awk -F '|' -v maxline=${CLEAN_MANIFEST_MAX_LINE} \
+    -v maxrecords=${CLEAN_MANIFEST_MAX_RECORDS} '
+	function hex64(value) {
+		return length(value) == 64 && value !~ /[^0-9a-f]/
+	}
+	length($0) > maxline || NR > maxrecords || NF != 3 || $1 == "" ||
+	    $2 !~ /^[0-9]+$/ || !hex64($3) { bad = 1; exit }
+	END { if (NR == 0 || bad) exit 1 }
+' "${CLEAN_WRKDIR}/bl"; then
+	echo "Malformed bl.gz" >&2
+	exit 1
+fi
+
+if ! awk -F '|' -v maxline=${CLEAN_MANIFEST_MAX_LINE} \
+    -v maxrecords=${CLEAN_MANIFEST_MAX_RECORDS} '
+	function hex64(value) {
+		return length(value) == 64 && value !~ /[^0-9a-f]/
+	}
+	length($0) > maxline || NR > maxrecords || NF != 3 || $1 == "" ||
+	    $2 !~ /^[0-9]+$/ || !hex64($3) { bad = 1; exit }
+	END { if (NR == 0 || bad) exit 1 }
+' "${CLEAN_WRKDIR}/tl"; then
+	echo "Malformed tl.gz" >&2
+	exit 1
+fi
+
+if ! awk -v maxline=${CLEAN_MANIFEST_MAX_LINE} \
+    -v maxrecords=${CLEAN_MANIFEST_MAX_RECORDS} '
+	function hex64(value) {
+		return length(value) == 64 && value !~ /[^0-9a-f]/
+	}
+	{
+		if (length($0) > maxline || NR > maxrecords) {
+			bad = 1
+			exit
+		}
+		if (substr($0, 1, 2) == "t/" && hex64(substr($0, 3))) {
+			tags++
+			tag_hash[substr($0, 3)] = 1
+			next
+		}
+		if (substr($0, 1, 2) == "s/" &&
+		    substr($0, length($0) - 3) == ".tgz" &&
+		    hex64(substr($0, 3, length($0) - 6))) {
+			snapshots++
+			snapshot_hash[substr($0, 3, length($0) - 6)] = 1
+			next
+		}
+		bad = 1
+		exit
+	}
+	END {
+		for (hash in snapshot_hash)
+			if (!(hash in tag_hash)) bad = 1
+		if (NR == 0 || tags == 0 || snapshots == 0 || bad) exit 1
+	}
+' "${CLEAN_WRKDIR}/el"; then
+	echo "Malformed el.gz" >&2
+	exit 1
+fi
+
+controls_unchanged () {
+	for CLEAN_CONTROL in bl.gz tl.gz el.gz latest.ssl pub.ssl snapshot.ssl; do
+		[ -f "${CLEAN_PUBDIR}/${CLEAN_CONTROL}" ] &&
+		    ! [ -L "${CLEAN_PUBDIR}/${CLEAN_CONTROL}" ] || return 1
+		cmp -s "${CLEAN_WRKDIR}/${CLEAN_CONTROL}" \
+		    "${CLEAN_PUBDIR}/${CLEAN_CONTROL}" || return 1
+	done
+}
+
+if ! controls_unchanged; then
+	echo "Publication changed while manifests were being read; retry later" >&2
+	exit 1
+fi
+
+awk -F '|' '{ print $3 }' "${CLEAN_WRKDIR}/bl" | sort -u \
+    > "${CLEAN_WRKDIR}/bl.hashes"
+awk -F '|' '{ print $3 }' "${CLEAN_WRKDIR}/tl" | sort -u \
+    > "${CLEAN_WRKDIR}/tl.hashes"
+
+: > "${CLEAN_WRKDIR}/live"
+awk '{ print "f/" $1 ".gz" }' "${CLEAN_WRKDIR}/bl.hashes" \
+    "${CLEAN_WRKDIR}/tl.hashes" >> "${CLEAN_WRKDIR}/live"
+sed -n -e '/^t\//p' -e '/^s\//p' "${CLEAN_WRKDIR}/el" \
+    >> "${CLEAN_WRKDIR}/live"
+
+: > "${CLEAN_WRKDIR}/present"
+: > "${CLEAN_WRKDIR}/unexpected"
+: > "${CLEAN_WRKDIR}/tp.names"
+for CLEAN_SUBDIR in ${CLEAN_SUBDIRS}; do
+	( cd "${CLEAN_PUBDIR}/${CLEAN_SUBDIR}" &&
+	    find . -maxdepth 1 -type f -print ) |
+	    sed 's#^\./##' > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all"
+	case ${CLEAN_SUBDIR} in
+	bp)
+		grep -E '^[0-9a-f]{64}-[0-9a-f]{64}$' \
+		    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+		    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" || true
+		;;
+	f)
+		grep -E '^[0-9a-f]{64}\.gz$' \
+		    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+		    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" || true
+		;;
+	s)
+		grep -E '^[0-9a-f]{64}\.tgz$' \
+		    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+		    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" || true
+		;;
+	t)
+		grep -E '^[0-9a-f]{64}$' \
+		    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+		    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" || true
+		;;
+	tp)
+		grep -E '^[0-9a-f]{64}-[0-9a-f]{64}\.gz$' \
+		    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+		    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" || true
+		;;
+	esac
+	sed "s#^#${CLEAN_SUBDIR}/#" \
+	    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" \
+	    >> "${CLEAN_WRKDIR}/present"
+	sort -u "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all" \
+	    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all.sorted"
+	sort -u "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names" \
+	    > "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names.sorted"
+	comm -23 "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.all.sorted" \
+	    "${CLEAN_WRKDIR}/${CLEAN_SUBDIR}.names.sorted" |
+	    sed "s#^#${CLEAN_SUBDIR}/#" \
+	    >> "${CLEAN_WRKDIR}/unexpected" || true
+done
+
+awk '
+	NR == FNR { hashes[$1] = 1; next }
+	{
+		split($0, pair, "-")
+		if (hashes[pair[1]] && hashes[pair[2]]) print "bp/" $0
+	}
+' "${CLEAN_WRKDIR}/bl.hashes" "${CLEAN_WRKDIR}/bp.names" \
+    >> "${CLEAN_WRKDIR}/live"
+sed 's/\.gz$//' "${CLEAN_WRKDIR}/tp.names" > "${CLEAN_WRKDIR}/tp.pairs"
+awk '
+	NR == FNR { hashes[$1] = 1; next }
+	{
+		split($0, pair, "-")
+		if (hashes[pair[1]] && hashes[pair[2]]) print "tp/" $0 ".gz"
+	}
+' "${CLEAN_WRKDIR}/tl.hashes" "${CLEAN_WRKDIR}/tp.pairs" \
+    >> "${CLEAN_WRKDIR}/live"
+
+sort -u "${CLEAN_WRKDIR}/live" > "${CLEAN_WRKDIR}/live.sorted"
+sort -u "${CLEAN_WRKDIR}/present" > "${CLEAN_WRKDIR}/present.sorted"
+comm -23 "${CLEAN_WRKDIR}/present.sorted" \
+    "${CLEAN_WRKDIR}/live.sorted" > "${CLEAN_WRKDIR}/candidates"
+
+if [ ${CLEAN_APPLY} = yes ]; then
+	mkdir -p "${CLEAN_STATE_DIR}" "${CLEAN_QUARANTINE_DIR}"
+	chmod 700 "${CLEAN_STATE_DIR}" "${CLEAN_QUARANTINE_DIR}"
+	CLEAN_LOCKDIR=${CLEAN_STATE_DIR}/lock
+	if ! mkdir "${CLEAN_LOCKDIR}" 2>/dev/null; then
+		echo "Another cleanup run is active, or ${CLEAN_LOCKDIR} is stale" >&2
+		exit 1
+	fi
+fi
+
+: > "${CLEAN_WRKDIR}/old-state"
+if [ -f "${CLEAN_STATE_DIR}/candidates" ]; then
+	if [ -L "${CLEAN_STATE_DIR}/candidates" ]; then
+		echo "Refusing symlinked cleanup state" >&2
+		exit 1
+	fi
+	cp "${CLEAN_STATE_DIR}/candidates" "${CLEAN_WRKDIR}/old-state"
+	if ! awk -F '|' '
+		NF != 2 || $1 == "" || $1 ~ /[^0-9a-z.\/-]/ ||
+		    $1 ~ /\.\./ || $1 !~ /^(bp|f|s|t|tp)\// ||
+		    $2 !~ /^[0-9]+$/ { exit 1 }
+	' "${CLEAN_WRKDIR}/old-state"; then
+		echo "Malformed cleanup state" >&2
+		exit 1
+	fi
+fi
+
+awk -F '|' -v now=${CLEAN_NOW} '
+	FILENAME == ARGV[1] { first_seen[$1] = $2; next }
+	{
+		if ($1 in first_seen) print $1 "|" first_seen[$1]
+		else print $1 "|" now
+	}
+' "${CLEAN_WRKDIR}/old-state" "${CLEAN_WRKDIR}/candidates" |
+    sort -t '|' -k 1,1 > "${CLEAN_WRKDIR}/new-state"
+awk -F '|' -v cutoff=${CLEAN_CUTOFF} '$2 <= cutoff { print $1 }' \
+    "${CLEAN_WRKDIR}/new-state" > "${CLEAN_WRKDIR}/due"
+
+: > "${CLEAN_WRKDIR}/purge"
+if [ -d "${CLEAN_QUARANTINE_DIR}" ] &&
+    ! [ -L "${CLEAN_QUARANTINE_DIR}" ]; then
+	for CLEAN_BATCH in "${CLEAN_QUARANTINE_DIR}"/*; do
+		[ -e "${CLEAN_BATCH}" ] || continue
+		[ -d "${CLEAN_BATCH}" ] && ! [ -L "${CLEAN_BATCH}" ] || continue
+		CLEAN_BATCH_NAME=${CLEAN_BATCH##*/}
+		CLEAN_BATCH_TIME=${CLEAN_BATCH_NAME%%.*}
+		CLEAN_BATCH_PID=${CLEAN_BATCH_NAME#*.}
+		case ${CLEAN_BATCH_TIME} in
+		''|*[!0-9]*) continue ;;
+		esac
+		case ${CLEAN_BATCH_PID} in
+		''|*[!0-9]*) continue ;;
+		esac
+		if [ ${CLEAN_BATCH_TIME} -lt ${CLEAN_QUARANTINE_CUTOFF} ]; then
+			echo "${CLEAN_BATCH}" >> "${CLEAN_WRKDIR}/purge"
+		fi
+	done
+fi
+
+CLEAN_PRESENT_COUNT=`wc -l < "${CLEAN_WRKDIR}/present.sorted"`
+CLEAN_LIVE_COUNT=`wc -l < "${CLEAN_WRKDIR}/live.sorted"`
+CLEAN_CANDIDATE_COUNT=`wc -l < "${CLEAN_WRKDIR}/candidates"`
+CLEAN_DUE_COUNT=`wc -l < "${CLEAN_WRKDIR}/due"`
+CLEAN_PURGE_COUNT=`wc -l < "${CLEAN_WRKDIR}/purge"`
+echo "`date`: ${CLEAN_PRESENT_COUNT} managed objects, ${CLEAN_LIVE_COUNT} live paths"
+echo "`date`: ${CLEAN_CANDIDATE_COUNT} unreferenced, ${CLEAN_DUE_COUNT} past the ${CLEAN_GRACE_DAYS}-day grace period"
+echo "`date`: ${CLEAN_PURGE_COUNT} quarantine batches past the ${CLEAN_QUARANTINE_DAYS}-day retention period"
+while read CLEAN_UNEXPECTED; do
+	[ -n "${CLEAN_UNEXPECTED}" ] || continue
+	echo "Ignoring unexpected file ${CLEAN_UNEXPECTED}" >&2
+done < "${CLEAN_WRKDIR}/unexpected"
+
+if [ ${CLEAN_APPLY} = no ]; then
+	while read CLEAN_DUE_PATH; do
+		[ -n "${CLEAN_DUE_PATH}" ] || continue
+		echo "Would quarantine ${CLEAN_DUE_PATH}"
+	done < "${CLEAN_WRKDIR}/due"
+	while read CLEAN_PURGE_PATH; do
+		[ -n "${CLEAN_PURGE_PATH}" ] || continue
+		echo "Would purge ${CLEAN_PURGE_PATH}"
+	done < "${CLEAN_WRKDIR}/purge"
+	echo "Dry run only; use --apply to update state and quarantine objects"
+	exit 0
+fi
+
+if ! controls_unchanged; then
+	echo "Publication changed before cleanup; retry later" >&2
+	exit 1
+fi
+
+CLEAN_BATCH_DIR=
+if [ -s "${CLEAN_WRKDIR}/due" ]; then
+	CLEAN_BATCH_DIR=${CLEAN_QUARANTINE_DIR}/${CLEAN_NOW}.$$
+	mkdir "${CLEAN_BATCH_DIR}"
+	while read CLEAN_DUE_PATH; do
+		[ -n "${CLEAN_DUE_PATH}" ] || continue
+		CLEAN_SOURCE=${CLEAN_PUBDIR}/${CLEAN_DUE_PATH}
+		if [ -L "${CLEAN_SOURCE}" ] || ! [ -f "${CLEAN_SOURCE}" ]; then
+			echo "Candidate changed before quarantine: ${CLEAN_DUE_PATH}" >&2
+			exit 1
+		fi
+		CLEAN_DESTDIR=${CLEAN_BATCH_DIR}/${CLEAN_DUE_PATH%/*}
+		mkdir -p "${CLEAN_DESTDIR}"
+		mv "${CLEAN_SOURCE}" "${CLEAN_DESTDIR}/"
+		echo "Quarantined ${CLEAN_DUE_PATH}"
+	done < "${CLEAN_WRKDIR}/due"
+fi
+
+awk -F '|' '
+	FILENAME == ARGV[1] { due[$1] = 1; next }
+	!($1 in due) { print }
+' "${CLEAN_WRKDIR}/due" "${CLEAN_WRKDIR}/new-state" \
+    > "${CLEAN_STATE_DIR}/candidates.new"
+mv "${CLEAN_STATE_DIR}/candidates.new" "${CLEAN_STATE_DIR}/candidates"
+
+while read CLEAN_PURGE_PATH; do
+	[ -n "${CLEAN_PURGE_PATH}" ] || continue
+	case ${CLEAN_PURGE_PATH} in
+	"${CLEAN_QUARANTINE_DIR}"/*) ;;
+	*)
+		echo "Refusing unsafe quarantine purge path" >&2
+		exit 1
+		;;
+	esac
+	rm -r "${CLEAN_PURGE_PATH}"
+	echo "Purged ${CLEAN_PURGE_PATH}"
+done < "${CLEAN_WRKDIR}/purge"
+
+echo "`date`: Cleanup complete"

--- a/tests/cleanup-regression.sh
+++ b/tests/cleanup-regression.sh
@@ -1,0 +1,134 @@
+#!/bin/sh -e
+
+set -e
+umask 077
+
+TEST_TMP=`mktemp -d "${TMPDIR:-/tmp}/portsnap-clean-test.XXXXXX"` || exit 1
+cleanup () {
+	if [ -n "${TEST_TMP}" ] && [ -d "${TEST_TMP}" ]; then
+		rm -r "${TEST_TMP}"
+	fi
+}
+trap cleanup 0
+trap 'exit 1' 1 2 15
+
+TEST_PUB=${TEST_TMP}/htmldocs
+TEST_STATE=${TEST_TMP}/.portsnap-clean
+mkdir -p "${TEST_PUB}/bp" "${TEST_PUB}/f" "${TEST_PUB}/s" \
+	"${TEST_PUB}/t" "${TEST_PUB}/tp"
+
+TEST_A=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+TEST_B=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+TEST_C=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+TEST_D=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+TEST_E=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+TEST_F=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+write_controls () {
+	printf 'file|200000|%s\nfile|200001|%s\n' "${TEST_A}" "${TEST_B}" |
+		gzip -c > "${TEST_PUB}/bl.gz"
+	printf 'INDEX|200000|%s\nINDEX|200001|%s\n' "${TEST_C}" "${TEST_D}" |
+		gzip -c > "${TEST_PUB}/tl.gz"
+	printf 's/%s.tgz\nt/%s\nt/%s\n' "${TEST_E}" "${TEST_E}" "${TEST_F}" |
+		gzip -c > "${TEST_PUB}/el.gz"
+	printf 'latest\n' > "${TEST_PUB}/latest.ssl"
+	printf 'public\n' > "${TEST_PUB}/pub.ssl"
+	printf 'snapshot\n' > "${TEST_PUB}/snapshot.ssl"
+}
+
+write_controls
+for TEST_PATH in \
+	"f/${TEST_A}.gz" "f/${TEST_B}.gz" "f/${TEST_C}.gz" "f/${TEST_D}.gz" \
+	"bp/${TEST_A}-${TEST_B}" "s/${TEST_E}.tgz" "t/${TEST_E}" "t/${TEST_F}" \
+	"tp/${TEST_C}-${TEST_D}.gz"; do
+	printf 'live\n' > "${TEST_PUB}/${TEST_PATH}"
+done
+for TEST_PATH in \
+	"f/${TEST_E}.gz" "bp/${TEST_E}-${TEST_F}" "s/${TEST_F}.tgz" \
+	"t/${TEST_A}" "tp/${TEST_E}-${TEST_F}.gz"; do
+	printf 'stale\n' > "${TEST_PUB}/${TEST_PATH}"
+done
+printf 'operator file\n' > "${TEST_PUB}/f/README"
+
+if ! sh ./portsnap-clean.sh --grace-days 0 "${TEST_PUB}" \
+	> "${TEST_TMP}/dry-run" 2>&1; then
+	cat "${TEST_TMP}/dry-run"
+	exit 1
+fi
+[ ! -e "${TEST_STATE}" ]
+[ -f "${TEST_PUB}/f/${TEST_E}.gz" ]
+grep -q "Would quarantine f/${TEST_E}.gz" "${TEST_TMP}/dry-run"
+
+sh ./portsnap-clean.sh --apply --grace-days 1 "${TEST_PUB}" \
+	> "${TEST_TMP}/first-apply" 2>&1
+[ -f "${TEST_PUB}/f/${TEST_E}.gz" ]
+[ -s "${TEST_STATE}/candidates" ]
+sed 's/|[0-9][0-9]*$/|1/' "${TEST_STATE}/candidates" \
+	> "${TEST_STATE}/candidates.old"
+mv "${TEST_STATE}/candidates.old" "${TEST_STATE}/candidates"
+
+sh ./portsnap-clean.sh --apply --grace-days 1 "${TEST_PUB}" \
+	> "${TEST_TMP}/second-apply" 2>&1
+for TEST_PATH in \
+	"f/${TEST_E}.gz" "bp/${TEST_E}-${TEST_F}" "s/${TEST_F}.tgz" \
+	"t/${TEST_A}" "tp/${TEST_E}-${TEST_F}.gz"; do
+	[ ! -e "${TEST_PUB}/${TEST_PATH}" ]
+	done
+for TEST_PATH in \
+	"f/${TEST_A}.gz" "f/${TEST_B}.gz" "f/${TEST_C}.gz" "f/${TEST_D}.gz" \
+	"bp/${TEST_A}-${TEST_B}" "s/${TEST_E}.tgz" "t/${TEST_E}" "t/${TEST_F}" \
+	"tp/${TEST_C}-${TEST_D}.gz" "f/README"; do
+	[ -f "${TEST_PUB}/${TEST_PATH}" ]
+done
+[ `find "${TEST_STATE}/quarantine" -type f | wc -l` -eq 5 ]
+
+printf 'candidate\n' > "${TEST_PUB}/f/${TEST_E}.gz"
+sh ./portsnap-clean.sh --apply --grace-days 1 "${TEST_PUB}" >/dev/null
+grep -q "f/${TEST_E}.gz" "${TEST_STATE}/candidates"
+printf 'restored|200002|%s\n' "${TEST_E}" > "${TEST_TMP}/tl.extra"
+gunzip -c "${TEST_PUB}/tl.gz" >> "${TEST_TMP}/tl.extra"
+gzip -c "${TEST_TMP}/tl.extra" > "${TEST_PUB}/tl.gz"
+sh ./portsnap-clean.sh --apply --grace-days 1 "${TEST_PUB}" >/dev/null
+! grep -q "f/${TEST_E}.gz" "${TEST_STATE}/candidates"
+[ -f "${TEST_PUB}/f/${TEST_E}.gz" ]
+
+cp "${TEST_PUB}/el.gz" "${TEST_TMP}/el.valid.gz"
+printf 's/%s.tgz\nt/%s\n' "${TEST_E}" "${TEST_F}" |
+	gzip -c > "${TEST_PUB}/el.gz"
+if sh ./portsnap-clean.sh --apply --grace-days 0 "${TEST_PUB}" \
+	> "${TEST_TMP}/incomplete-el-output" 2>&1; then
+	echo "Incomplete snapshot manifest cleanup unexpectedly succeeded" >&2
+	exit 1
+fi
+mv "${TEST_TMP}/el.valid.gz" "${TEST_PUB}/el.gz"
+
+cp "${TEST_PUB}/bl.gz" "${TEST_TMP}/bl.valid.gz"
+printf 'malformed\n' | gzip -c > "${TEST_PUB}/bl.gz"
+if sh ./portsnap-clean.sh --apply --grace-days 0 "${TEST_PUB}" \
+	> "${TEST_TMP}/malformed-output" 2>&1; then
+	echo "Malformed manifest cleanup unexpectedly succeeded" >&2
+	exit 1
+fi
+[ -f "${TEST_PUB}/f/${TEST_E}.gz" ]
+mv "${TEST_TMP}/bl.valid.gz" "${TEST_PUB}/bl.gz"
+
+mkdir -p "${TEST_STATE}/quarantine/1.1/f"
+printf 'old quarantine\n' > "${TEST_STATE}/quarantine/1.1/f/old.gz"
+sh ./portsnap-clean.sh --apply --quarantine-days 1 "${TEST_PUB}" >/dev/null
+[ ! -e "${TEST_STATE}/quarantine/1.1" ]
+
+TEST_NO_TP=${TEST_TMP}/secondary/htmldocs
+mkdir -p "${TEST_NO_TP}/bp" "${TEST_NO_TP}/f" "${TEST_NO_TP}/s" \
+	"${TEST_NO_TP}/t"
+cp "${TEST_PUB}/bl.gz" "${TEST_PUB}/tl.gz" "${TEST_PUB}/el.gz" \
+	"${TEST_PUB}/latest.ssl" "${TEST_PUB}/pub.ssl" \
+	"${TEST_PUB}/snapshot.ssl" "${TEST_NO_TP}/"
+sh ./portsnap-clean.sh "${TEST_NO_TP}" >/dev/null
+[ ! -e "${TEST_TMP}/secondary/.portsnap-clean" ]
+chmod g+w "${TEST_NO_TP}"
+if sh ./portsnap-clean.sh "${TEST_NO_TP}" >/dev/null 2>&1; then
+	echo "Writable publication directory cleanup unexpectedly succeeded" >&2
+	exit 1
+fi
+
+echo "Manifest-aware cleanup regression tests passed"


### PR DESCRIPTION
## Summary

- add a primary-webserver cleanup utility driven by the published portsnap manifests
- retain referenced objects and quarantine stale unreferenced objects before deletion
- default to dry-run mode and include safety checks for publication and state directories
- document deployment and locking alongside the builder-to-webserver rsync workflow
- add regression coverage for retention, quarantine, deletion, and manifest-change safeguards

## Testing

- sh tests/cleanup-regression.sh
- sh tests/f2-regression.sh
- sh -n portsnap-clean.sh
- sh -n tests/cleanup-regression.sh
- sh -n pmirror.sh
- git diff --check

## Summary by Sourcery

Introduce a fail-closed, manifest-driven cleanup workflow for safely retiring stale Portsnap web-root objects.

New Features:
- Add a manifest-aware cleanup utility for primary rsync web roots that retains referenced objects and quarantines stale unreferenced objects before deletion.

Enhancements:
- Add fail-closed safety checks for publication and cleanup state directories, manifest validity, concurrent publication changes, unexpected files, and cleanup locking.
- Default cleanup to dry-run mode with configurable grace and quarantine retention periods.

Deployment:
- Document primary-webserver cleanup deployment and coordination with the builder-to-webserver rsync workflow.

Documentation:
- Document cleanup usage, retention behavior, locking, safety guarantees, and regression commands.

Tests:
- Add regression coverage for dry runs, retention, quarantine and purge behavior, restored references, malformed or incomplete manifests, and directory safety checks.